### PR TITLE
Support raster image layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -30,6 +30,7 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
+    "fast-deep-equal": "^3.1.3",
     "mapbox-gl": "^1.11.1",
     "mapbox-gl-controls": "^1.6.4",
     "use-deep-compare-effect": "^1.3.1"

--- a/src/components/layers/RasterLayer/index.tsx
+++ b/src/components/layers/RasterLayer/index.tsx
@@ -3,7 +3,7 @@ import MapboxContext from "../../../contexts/MapboxContext";
 import useDeepCompareEffect from "use-deep-compare-effect";
 
 const RasterLayer: React.FC<{
-  sourceOptions: mapboxgl.RasterSource;
+  sourceOptions: mapboxgl.RasterSource | mapboxgl.ImageSourceRaw;
   minzoom?: number;
   maxzoom?: number;
   id: string;
@@ -36,7 +36,10 @@ const RasterLayer: React.FC<{
         type: "raster",
         minzoom,
         maxzoom,
-        paint: paintOptions ?? {},
+        paint:
+          opacity !== undefined
+            ? { ...(paintOptions ?? {}), "raster-opacity": opacity }
+            : paintOptions ?? {},
         layout: layoutOptions ?? {},
       },
       beforeLayer

--- a/src/components/layers/RasterLayer/index.tsx
+++ b/src/components/layers/RasterLayer/index.tsx
@@ -36,7 +36,10 @@ const RasterLayer: React.FC<{
         type: "raster",
         minzoom,
         maxzoom,
-        paint: paintOptions ?? {},
+        paint:
+          opacity !== undefined
+            ? { ...(paintOptions ?? {}), "raster-opacity": opacity }
+            : paintOptions ?? {},
         layout: layoutOptions ?? {},
       },
       beforeLayer

--- a/src/components/layers/RasterLayer/index.tsx
+++ b/src/components/layers/RasterLayer/index.tsx
@@ -36,10 +36,7 @@ const RasterLayer: React.FC<{
         type: "raster",
         minzoom,
         maxzoom,
-        paint:
-          opacity !== undefined
-            ? { ...(paintOptions ?? {}), "raster-opacity": opacity }
-            : paintOptions ?? {},
+        paint: paintOptions ?? {},
         layout: layoutOptions ?? {},
       },
       beforeLayer


### PR DESCRIPTION
Mapbox layers of type `raster` can have either a `RasterSource` or `ImageSource` backing them. This PR just updates the types of the `RasterLayer` component to support either.