### PR TITLE
Add interactive line layer component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/components/layers/InteractiveLineLayer/InteractiveLineLayer.stories.tsx
+++ b/src/components/layers/InteractiveLineLayer/InteractiveLineLayer.stories.tsx
@@ -1,0 +1,243 @@
+import React, { useState, useEffect, useContext, useRef, useMemo } from "react";
+
+import { MapboxContext } from "../../MapboxMap";
+import LineLayer, { LineLayerProps, LineCoordinates } from "../LineLayer";
+import { LngLat } from "mapbox-gl";
+import {
+  InteractiveBaseType,
+  MapEventHandler,
+  NativeMapEventHandler,
+} from "../../../hooks/useMapInteractions";
+
+export type InteractiveLineData = InteractiveBaseType & {
+  coordinates: LineCoordinates;
+};
+
+export type InteractiveLineLayerProps = LineLayerProps & {
+  lines: InteractiveLineData[];
+
+  onClick?: MapEventHandler;
+  onHoverEnter?: MapEventHandler;
+  onHoverLeave?: MapEventHandler;
+};
+
+/** A controlled component that fires the appropriate callback for user events
+ *  on an underlying line layer. Since this is a controlled component, it does
+ *  not actually manage the hover state of each line or move lines as they
+ *  are dragged— that responsibility is left up to a higher level component.
+ */
+const InteractiveLineLayer: React.FC<InteractiveLineLayerProps> = ({
+  lines,
+  onClick,
+  onHoverEnter,
+  onHoverLeave,
+}) => {
+  // Index lines by ID for fast lookup
+  const lineIndex = useMemo(
+    () =>
+      lines.reduce((accum: Record<string, InteractiveLineData>, p) => {
+        accum[p.id] = p;
+        return accum;
+      }, {}),
+    [lines]
+  );
+
+  // Keep track of the last feature we were hovering over to trigger separate
+  // hoverEnter and hoverLeave events
+  const lastHoverId = useRef<string | number | null>(null);
+  const dragging = useRef<{
+    pointID: string | number;
+    offset: mapboxgl.Point;
+  } | null>(null);
+
+  // Flag set once the underlying point layer has been added to the map
+  const [LineLayerID, setLineLayerID] = useState<string | null>(null);
+  const { map } = useContext(MapboxContext);
+
+  // Set up event handlers
+  useEffect(() => {
+    if (!map || LineLayerID === null) return;
+    const handleClick: NativeMapEventHandler = (e) => {
+      const id =
+        getPointsSortedByDistance(e)?.find((f) => {
+          if (f.id === null) return false;
+          const match = lineIndex[f.id];
+          return match && match.clickable;
+        })?.id ?? null;
+      if (id === undefined || id === null) return;
+
+      onClick?.(id, e);
+    };
+    // Handle hover events and drag events
+    const handleMouseMove: NativeMapEventHandler = (e) => {
+      // Don't do anything if we're currently dragging a point
+      if (dragging.current !== null) return;
+      const sortedFeatures = getPointsSortedByDistance(e);
+      const closestHoverableID =
+        sortedFeatures?.find((f) => {
+          if (f.id === null) return false;
+          const match = lineIndex[f.id];
+          return match && match.hoverable;
+        })?.id ?? null;
+
+      // Only fire hover events if the feature beneath the pointer has changed
+      if (closestHoverableID !== lastHoverId.current) {
+        if (lastHoverId.current !== null) {
+          onHoverLeave?.(lastHoverId.current, e);
+        }
+
+        if (closestHoverableID !== null) onHoverEnter?.(closestHoverableID, e);
+        lastHoverId.current = closestHoverableID;
+      }
+    };
+
+    const handleDrag: NativeMapEventHandler<
+      mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+    > = (e) => {
+      if ((e.originalEvent as TouchEvent).touches?.length > 1) {
+        e.preventDefault();
+        return;
+      }
+      // Fire a drag event if currently dragging anything
+      if (dragging.current !== null) {
+        const pointerProjected = map.project(e.lngLat);
+        const offsetLngLat = map.unproject(
+          pointerProjected.sub(dragging.current.offset)
+        );
+        onDrag?.(
+          dragging.current.pointID,
+          { longitude: offsetLngLat.lng, latitude: offsetLngLat.lat },
+          dragging.current.offset,
+          e
+        );
+      }
+    };
+
+    const handleMouseDown: NativeMapEventHandler<
+      mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+    > = (e) => {
+      // Don't handle a touchstart event if we're already dragging something
+      if (e.type === "touchstart" && dragging.current !== null) {
+        return;
+      }
+      const closestFeature = getPointsSortedByDistance(e)?.find((f) => {
+        if (f.id === null) return false;
+        const match = lineIndex[f.id];
+        return match && match.draggable;
+      });
+
+      const id = closestFeature?.id ?? null;
+
+      if (
+        id === null ||
+        !closestFeature ||
+        closestFeature.geometry?.type !== "Point"
+      )
+        return;
+
+      // Start a new drag event
+      const pointProjected = map.project(
+        closestFeature.geometry.coordinates as [number, number]
+      );
+      const pointerProjected = map.project(e.lngLat);
+      const offset = pointerProjected.sub(pointProjected);
+
+      dragging.current = { pointID: id, offset };
+
+      onDragStart?.(id, offset, e);
+      e.preventDefault();
+    };
+
+    const handleMouseUp = (e: any) => {
+      if (dragging.current === null) return;
+      onDragEnd?.(dragging.current.pointID, e);
+      dragging.current = null;
+
+      if (lastHoverId.current !== null) {
+        onHoverLeave?.(lastHoverId.current, e);
+        lastHoverId.current = null;
+      }
+    };
+
+    // Events for click and hover handlers
+    map.on("click", LineLayerID, handleClick);
+    map.on("mousemove", LineLayerID, handleMouseMove);
+    map.on("mouseleave", LineLayerID, handleMouseMove);
+
+    // Events for drag handlers
+    map.on("mousedown", LineLayerID, handleMouseDown);
+    map.on("mousemove", handleDrag);
+    map.on("mouseup", handleMouseUp);
+
+    map.on("touchstart", LineLayerID, handleMouseDown);
+    map.on("touchmove", handleDrag);
+    map.on("touchend", handleMouseUp);
+    map.on("touchcancel", handleMouseUp);
+
+    // Make sure to capture pointerup events anywhere in the window
+    window.addEventListener("pointerup", handleMouseUp);
+
+    // Clean up events when we're done
+    return () => {
+      map.off("click", LineLayerID, handleClick);
+      map.off("mousemove", LineLayerID, handleMouseMove);
+      map.off("mouseleave", LineLayerID, handleMouseMove);
+
+      map.off("mousedown", LineLayerID, handleMouseDown);
+      map.off("mousemove", handleDrag);
+      map.off("mouseup", handleMouseUp);
+
+      map.off("touchstart", LineLayerID, handleMouseDown);
+      map.off("touchmove", handleDrag);
+      map.off("touchend", handleMouseUp);
+      map.off("touchcancel", handleMouseUp);
+
+      window.removeEventListener("pointerup", handleMouseUp);
+    };
+  }, [
+    map,
+    onClick,
+    onDrag,
+    onDragEnd,
+    onDragStart,
+    onHoverEnter,
+    onHoverLeave,
+    lineIndex,
+    LineLayerID,
+  ]);
+
+  return <LineLayer {...props} onAdd={setLineLayerID} />;
+};
+
+/** Given a Mapbox `MapMouseEvent`, sort any point features that the event
+ *  involves by their distance to the mouse in ascending order.
+ *
+ *  Mapbox doesn't have any native concept of event capturing, so the event it
+ *  fires will list out all the features that are hit. We most likely only want
+ *  to get the one closest to the mouse event.
+ */
+const getPointsSortedByDistance = (
+  e: (mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent) & {
+    features?: mapboxgl.MapboxGeoJSONFeature[] | undefined;
+  } & mapboxgl.EventData
+) => {
+  const features = e.features;
+  if (!features) return null;
+  const eventPoint = e.lngLat;
+
+  return features
+    .map((f) => ({
+      ...f,
+      id: (f.properties?.["id"] as number | string) ?? null,
+      geometry: f.geometry, // This is a getter and needs to be manually copied
+      distance:
+        f.geometry.type === "Point"
+          ? eventPoint.distanceTo(
+              new LngLat(f.geometry.coordinates[0], f.geometry.coordinates[1])
+            )
+          : Infinity,
+    }))
+    .sort((a, b) => a.distance - b.distance);
+};
+
+export default InteractiveLineLayer;

--- a/src/components/layers/InteractiveLineLayer/InteractiveLineLayer.stories.tsx
+++ b/src/components/layers/InteractiveLineLayer/InteractiveLineLayer.stories.tsx
@@ -1,243 +1,244 @@
-import React, { useState, useEffect, useContext, useRef, useMemo } from "react";
+export const foo = "";
+// import React, { useState, useEffect, useContext, useRef, useMemo } from "react";
 
-import { MapboxContext } from "../../MapboxMap";
-import LineLayer, { LineLayerProps, LineCoordinates } from "../LineLayer";
-import { LngLat } from "mapbox-gl";
-import {
-  InteractiveBaseType,
-  MapEventHandler,
-  NativeMapEventHandler,
-} from "../../../hooks/useMapInteractions";
+// import { MapboxContext } from "../../MapboxMap";
+// import LineLayer, { LineLayerProps, LineCoordinates } from "../LineLayer";
+// import { LngLat } from "mapbox-gl";
+// import {
+//   InteractiveBaseType,
+//   MapEventHandler,
+//   NativeMapEventHandler,
+// } from "../../../hooks/useMapInteractions";
 
-export type InteractiveLineData = InteractiveBaseType & {
-  coordinates: LineCoordinates;
-};
+// export type InteractiveLineData = InteractiveBaseType & {
+//   coordinates: LineCoordinates;
+// };
 
-export type InteractiveLineLayerProps = LineLayerProps & {
-  lines: InteractiveLineData[];
+// export type InteractiveLineLayerProps = LineLayerProps & {
+//   lines: InteractiveLineData[];
 
-  onClick?: MapEventHandler;
-  onHoverEnter?: MapEventHandler;
-  onHoverLeave?: MapEventHandler;
-};
+//   onClick?: MapEventHandler;
+//   onHoverEnter?: MapEventHandler;
+//   onHoverLeave?: MapEventHandler;
+// };
 
-/** A controlled component that fires the appropriate callback for user events
- *  on an underlying line layer. Since this is a controlled component, it does
- *  not actually manage the hover state of each line or move lines as they
- *  are dragged— that responsibility is left up to a higher level component.
- */
-const InteractiveLineLayer: React.FC<InteractiveLineLayerProps> = ({
-  lines,
-  onClick,
-  onHoverEnter,
-  onHoverLeave,
-}) => {
-  // Index lines by ID for fast lookup
-  const lineIndex = useMemo(
-    () =>
-      lines.reduce((accum: Record<string, InteractiveLineData>, p) => {
-        accum[p.id] = p;
-        return accum;
-      }, {}),
-    [lines]
-  );
+// /** A controlled component that fires the appropriate callback for user events
+//  *  on an underlying line layer. Since this is a controlled component, it does
+//  *  not actually manage the hover state of each line or move lines as they
+//  *  are dragged— that responsibility is left up to a higher level component.
+//  */
+// const InteractiveLineLayer: React.FC<InteractiveLineLayerProps> = ({
+//   lines,
+//   onClick,
+//   onHoverEnter,
+//   onHoverLeave,
+// }) => {
+//   // Index lines by ID for fast lookup
+//   const lineIndex = useMemo(
+//     () =>
+//       lines.reduce((accum: Record<string, InteractiveLineData>, p) => {
+//         accum[p.id] = p;
+//         return accum;
+//       }, {}),
+//     [lines]
+//   );
 
-  // Keep track of the last feature we were hovering over to trigger separate
-  // hoverEnter and hoverLeave events
-  const lastHoverId = useRef<string | number | null>(null);
-  const dragging = useRef<{
-    pointID: string | number;
-    offset: mapboxgl.Point;
-  } | null>(null);
+//   // Keep track of the last feature we were hovering over to trigger separate
+//   // hoverEnter and hoverLeave events
+//   const lastHoverId = useRef<string | number | null>(null);
+//   const dragging = useRef<{
+//     pointID: string | number;
+//     offset: mapboxgl.Point;
+//   } | null>(null);
 
-  // Flag set once the underlying point layer has been added to the map
-  const [LineLayerID, setLineLayerID] = useState<string | null>(null);
-  const { map } = useContext(MapboxContext);
+//   // Flag set once the underlying point layer has been added to the map
+//   const [LineLayerID, setLineLayerID] = useState<string | null>(null);
+//   const { map } = useContext(MapboxContext);
 
-  // Set up event handlers
-  useEffect(() => {
-    if (!map || LineLayerID === null) return;
-    const handleClick: NativeMapEventHandler = (e) => {
-      const id =
-        getPointsSortedByDistance(e)?.find((f) => {
-          if (f.id === null) return false;
-          const match = lineIndex[f.id];
-          return match && match.clickable;
-        })?.id ?? null;
-      if (id === undefined || id === null) return;
+//   // Set up event handlers
+//   useEffect(() => {
+//     if (!map || LineLayerID === null) return;
+//     const handleClick: NativeMapEventHandler = (e) => {
+//       const id =
+//         getPointsSortedByDistance(e)?.find((f) => {
+//           if (f.id === null) return false;
+//           const match = lineIndex[f.id];
+//           return match && match.clickable;
+//         })?.id ?? null;
+//       if (id === undefined || id === null) return;
 
-      onClick?.(id, e);
-    };
-    // Handle hover events and drag events
-    const handleMouseMove: NativeMapEventHandler = (e) => {
-      // Don't do anything if we're currently dragging a point
-      if (dragging.current !== null) return;
-      const sortedFeatures = getPointsSortedByDistance(e);
-      const closestHoverableID =
-        sortedFeatures?.find((f) => {
-          if (f.id === null) return false;
-          const match = lineIndex[f.id];
-          return match && match.hoverable;
-        })?.id ?? null;
+//       onClick?.(id, e);
+//     };
+//     // Handle hover events and drag events
+//     const handleMouseMove: NativeMapEventHandler = (e) => {
+//       // Don't do anything if we're currently dragging a point
+//       if (dragging.current !== null) return;
+//       const sortedFeatures = getPointsSortedByDistance(e);
+//       const closestHoverableID =
+//         sortedFeatures?.find((f) => {
+//           if (f.id === null) return false;
+//           const match = lineIndex[f.id];
+//           return match && match.hoverable;
+//         })?.id ?? null;
 
-      // Only fire hover events if the feature beneath the pointer has changed
-      if (closestHoverableID !== lastHoverId.current) {
-        if (lastHoverId.current !== null) {
-          onHoverLeave?.(lastHoverId.current, e);
-        }
+//       // Only fire hover events if the feature beneath the pointer has changed
+//       if (closestHoverableID !== lastHoverId.current) {
+//         if (lastHoverId.current !== null) {
+//           onHoverLeave?.(lastHoverId.current, e);
+//         }
 
-        if (closestHoverableID !== null) onHoverEnter?.(closestHoverableID, e);
-        lastHoverId.current = closestHoverableID;
-      }
-    };
+//         if (closestHoverableID !== null) onHoverEnter?.(closestHoverableID, e);
+//         lastHoverId.current = closestHoverableID;
+//       }
+//     };
 
-    const handleDrag: NativeMapEventHandler<
-      mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-    > = (e) => {
-      if ((e.originalEvent as TouchEvent).touches?.length > 1) {
-        e.preventDefault();
-        return;
-      }
-      // Fire a drag event if currently dragging anything
-      if (dragging.current !== null) {
-        const pointerProjected = map.project(e.lngLat);
-        const offsetLngLat = map.unproject(
-          pointerProjected.sub(dragging.current.offset)
-        );
-        onDrag?.(
-          dragging.current.pointID,
-          { longitude: offsetLngLat.lng, latitude: offsetLngLat.lat },
-          dragging.current.offset,
-          e
-        );
-      }
-    };
+//     const handleDrag: NativeMapEventHandler<
+//       mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+//     > = (e) => {
+//       if ((e.originalEvent as TouchEvent).touches?.length > 1) {
+//         e.preventDefault();
+//         return;
+//       }
+//       // Fire a drag event if currently dragging anything
+//       if (dragging.current !== null) {
+//         const pointerProjected = map.project(e.lngLat);
+//         const offsetLngLat = map.unproject(
+//           pointerProjected.sub(dragging.current.offset)
+//         );
+//         onDrag?.(
+//           dragging.current.pointID,
+//           { longitude: offsetLngLat.lng, latitude: offsetLngLat.lat },
+//           dragging.current.offset,
+//           e
+//         );
+//       }
+//     };
 
-    const handleMouseDown: NativeMapEventHandler<
-      mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-    > = (e) => {
-      // Don't handle a touchstart event if we're already dragging something
-      if (e.type === "touchstart" && dragging.current !== null) {
-        return;
-      }
-      const closestFeature = getPointsSortedByDistance(e)?.find((f) => {
-        if (f.id === null) return false;
-        const match = lineIndex[f.id];
-        return match && match.draggable;
-      });
+//     const handleMouseDown: NativeMapEventHandler<
+//       mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+//     > = (e) => {
+//       // Don't handle a touchstart event if we're already dragging something
+//       if (e.type === "touchstart" && dragging.current !== null) {
+//         return;
+//       }
+//       const closestFeature = getPointsSortedByDistance(e)?.find((f) => {
+//         if (f.id === null) return false;
+//         const match = lineIndex[f.id];
+//         return match && match.draggable;
+//       });
 
-      const id = closestFeature?.id ?? null;
+//       const id = closestFeature?.id ?? null;
 
-      if (
-        id === null ||
-        !closestFeature ||
-        closestFeature.geometry?.type !== "Point"
-      )
-        return;
+//       if (
+//         id === null ||
+//         !closestFeature ||
+//         closestFeature.geometry?.type !== "Point"
+//       )
+//         return;
 
-      // Start a new drag event
-      const pointProjected = map.project(
-        closestFeature.geometry.coordinates as [number, number]
-      );
-      const pointerProjected = map.project(e.lngLat);
-      const offset = pointerProjected.sub(pointProjected);
+//       // Start a new drag event
+//       const pointProjected = map.project(
+//         closestFeature.geometry.coordinates as [number, number]
+//       );
+//       const pointerProjected = map.project(e.lngLat);
+//       const offset = pointerProjected.sub(pointProjected);
 
-      dragging.current = { pointID: id, offset };
+//       dragging.current = { pointID: id, offset };
 
-      onDragStart?.(id, offset, e);
-      e.preventDefault();
-    };
+//       onDragStart?.(id, offset, e);
+//       e.preventDefault();
+//     };
 
-    const handleMouseUp = (e: any) => {
-      if (dragging.current === null) return;
-      onDragEnd?.(dragging.current.pointID, e);
-      dragging.current = null;
+//     const handleMouseUp = (e: any) => {
+//       if (dragging.current === null) return;
+//       onDragEnd?.(dragging.current.pointID, e);
+//       dragging.current = null;
 
-      if (lastHoverId.current !== null) {
-        onHoverLeave?.(lastHoverId.current, e);
-        lastHoverId.current = null;
-      }
-    };
+//       if (lastHoverId.current !== null) {
+//         onHoverLeave?.(lastHoverId.current, e);
+//         lastHoverId.current = null;
+//       }
+//     };
 
-    // Events for click and hover handlers
-    map.on("click", LineLayerID, handleClick);
-    map.on("mousemove", LineLayerID, handleMouseMove);
-    map.on("mouseleave", LineLayerID, handleMouseMove);
+//     // Events for click and hover handlers
+//     map.on("click", LineLayerID, handleClick);
+//     map.on("mousemove", LineLayerID, handleMouseMove);
+//     map.on("mouseleave", LineLayerID, handleMouseMove);
 
-    // Events for drag handlers
-    map.on("mousedown", LineLayerID, handleMouseDown);
-    map.on("mousemove", handleDrag);
-    map.on("mouseup", handleMouseUp);
+//     // Events for drag handlers
+//     map.on("mousedown", LineLayerID, handleMouseDown);
+//     map.on("mousemove", handleDrag);
+//     map.on("mouseup", handleMouseUp);
 
-    map.on("touchstart", LineLayerID, handleMouseDown);
-    map.on("touchmove", handleDrag);
-    map.on("touchend", handleMouseUp);
-    map.on("touchcancel", handleMouseUp);
+//     map.on("touchstart", LineLayerID, handleMouseDown);
+//     map.on("touchmove", handleDrag);
+//     map.on("touchend", handleMouseUp);
+//     map.on("touchcancel", handleMouseUp);
 
-    // Make sure to capture pointerup events anywhere in the window
-    window.addEventListener("pointerup", handleMouseUp);
+//     // Make sure to capture pointerup events anywhere in the window
+//     window.addEventListener("pointerup", handleMouseUp);
 
-    // Clean up events when we're done
-    return () => {
-      map.off("click", LineLayerID, handleClick);
-      map.off("mousemove", LineLayerID, handleMouseMove);
-      map.off("mouseleave", LineLayerID, handleMouseMove);
+//     // Clean up events when we're done
+//     return () => {
+//       map.off("click", LineLayerID, handleClick);
+//       map.off("mousemove", LineLayerID, handleMouseMove);
+//       map.off("mouseleave", LineLayerID, handleMouseMove);
 
-      map.off("mousedown", LineLayerID, handleMouseDown);
-      map.off("mousemove", handleDrag);
-      map.off("mouseup", handleMouseUp);
+//       map.off("mousedown", LineLayerID, handleMouseDown);
+//       map.off("mousemove", handleDrag);
+//       map.off("mouseup", handleMouseUp);
 
-      map.off("touchstart", LineLayerID, handleMouseDown);
-      map.off("touchmove", handleDrag);
-      map.off("touchend", handleMouseUp);
-      map.off("touchcancel", handleMouseUp);
+//       map.off("touchstart", LineLayerID, handleMouseDown);
+//       map.off("touchmove", handleDrag);
+//       map.off("touchend", handleMouseUp);
+//       map.off("touchcancel", handleMouseUp);
 
-      window.removeEventListener("pointerup", handleMouseUp);
-    };
-  }, [
-    map,
-    onClick,
-    onDrag,
-    onDragEnd,
-    onDragStart,
-    onHoverEnter,
-    onHoverLeave,
-    lineIndex,
-    LineLayerID,
-  ]);
+//       window.removeEventListener("pointerup", handleMouseUp);
+//     };
+//   }, [
+//     map,
+//     onClick,
+//     onDrag,
+//     onDragEnd,
+//     onDragStart,
+//     onHoverEnter,
+//     onHoverLeave,
+//     lineIndex,
+//     LineLayerID,
+//   ]);
 
-  return <LineLayer {...props} onAdd={setLineLayerID} />;
-};
+//   return <LineLayer {...props} onAdd={setLineLayerID} />;
+// };
 
-/** Given a Mapbox `MapMouseEvent`, sort any point features that the event
- *  involves by their distance to the mouse in ascending order.
- *
- *  Mapbox doesn't have any native concept of event capturing, so the event it
- *  fires will list out all the features that are hit. We most likely only want
- *  to get the one closest to the mouse event.
- */
-const getPointsSortedByDistance = (
-  e: (mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent) & {
-    features?: mapboxgl.MapboxGeoJSONFeature[] | undefined;
-  } & mapboxgl.EventData
-) => {
-  const features = e.features;
-  if (!features) return null;
-  const eventPoint = e.lngLat;
+// /** Given a Mapbox `MapMouseEvent`, sort any point features that the event
+//  *  involves by their distance to the mouse in ascending order.
+//  *
+//  *  Mapbox doesn't have any native concept of event capturing, so the event it
+//  *  fires will list out all the features that are hit. We most likely only want
+//  *  to get the one closest to the mouse event.
+//  */
+// const getPointsSortedByDistance = (
+//   e: (mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent) & {
+//     features?: mapboxgl.MapboxGeoJSONFeature[] | undefined;
+//   } & mapboxgl.EventData
+// ) => {
+//   const features = e.features;
+//   if (!features) return null;
+//   const eventPoint = e.lngLat;
 
-  return features
-    .map((f) => ({
-      ...f,
-      id: (f.properties?.["id"] as number | string) ?? null,
-      geometry: f.geometry, // This is a getter and needs to be manually copied
-      distance:
-        f.geometry.type === "Point"
-          ? eventPoint.distanceTo(
-              new LngLat(f.geometry.coordinates[0], f.geometry.coordinates[1])
-            )
-          : Infinity,
-    }))
-    .sort((a, b) => a.distance - b.distance);
-};
+//   return features
+//     .map((f) => ({
+//       ...f,
+//       id: (f.properties?.["id"] as number | string) ?? null,
+//       geometry: f.geometry, // This is a getter and needs to be manually copied
+//       distance:
+//         f.geometry.type === "Point"
+//           ? eventPoint.distanceTo(
+//               new LngLat(f.geometry.coordinates[0], f.geometry.coordinates[1])
+//             )
+//           : Infinity,
+//     }))
+//     .sort((a, b) => a.distance - b.distance);
+// };
 
-export default InteractiveLineLayer;
+// export default InteractiveLineLayer;

--- a/src/components/layers/InteractiveLineLayer/index.tsx
+++ b/src/components/layers/InteractiveLineLayer/index.tsx
@@ -1,0 +1,1 @@
+export const foo = "";

--- a/src/components/layers/InteractiveLineLayer/index.tsx
+++ b/src/components/layers/InteractiveLineLayer/index.tsx
@@ -6,6 +6,16 @@ import useMapLayerInteractions, {
   InteractiveLayerProps,
 } from "../../../hooks/useMapInteractions";
 
+type InteractiveLineProperties = {
+  /** Flag indicating whether this point should respond to drag events */
+  draggable?: boolean;
+
+  /** Flag indicating whether this point should respond to click events */
+  clickable?: boolean;
+
+  /** Flag indicating whether this point should respond to hover events */
+  hoverable?: boolean;
+};
 export type InteractiveLineData = {
   /** Unique ID for this point that will be passed to all interaction event
    *  handlers
@@ -17,21 +27,17 @@ export type InteractiveLineData = {
   /** Any data you want to make available to Mapbox style functions must go
    *  in the `properties` key
    */
-  properties: GeoJSON.GeoJsonProperties & {
-    /** Flag indicating whether this point should respond to drag events */
-    draggable?: boolean;
-
-    /** Flag indicating whether this point should respond to click events */
-    clickable?: boolean;
-
-    /** Flag indicating whether this point should respond to hover events */
-    hoverable?: boolean;
-  };
+  properties: GeoJSON.GeoJsonProperties & InteractiveLineProperties;
 };
 
 export type InteractiveLineLayerProps = LineLayerProps &
   InteractiveLayerProps & {
-    lines: InteractiveLineData[];
+    lines:
+      | InteractiveLineData[]
+      | GeoJSON.FeatureCollection<
+          GeoJSON.LineString | GeoJSON.MultiLineString,
+          InteractiveLineProperties
+        >;
   };
 
 /** A controlled component that fires the appropriate callback for user events

--- a/src/components/layers/InteractiveLineLayer/index.tsx
+++ b/src/components/layers/InteractiveLineLayer/index.tsx
@@ -1,1 +1,75 @@
-export const foo = "";
+import React, { useState, useContext } from "react";
+
+import { MapboxContext } from "../../MapboxMap";
+import LineLayer, { LineLayerProps, LineCoordinates } from "../LineLayer";
+import useMapLayerInteractions, {
+  InteractiveLayerProps,
+} from "../../../hooks/useMapInteractions";
+
+export type InteractiveLineData = {
+  /** Unique ID for this point that will be passed to all interaction event
+   *  handlers
+   */
+  id: string | number;
+
+  coordinates: LineCoordinates;
+
+  /** Any data you want to make available to Mapbox style functions must go
+   *  in the `properties` key
+   */
+  properties: GeoJSON.GeoJsonProperties & {
+    /** Flag indicating whether this point should respond to drag events */
+    draggable?: boolean;
+
+    /** Flag indicating whether this point should respond to click events */
+    clickable?: boolean;
+
+    /** Flag indicating whether this point should respond to hover events */
+    hoverable?: boolean;
+  };
+};
+
+export type InteractiveLineLayerProps = LineLayerProps &
+  InteractiveLayerProps & {
+    lines: InteractiveLineData[];
+  };
+
+/** A controlled component that fires the appropriate callback for user events
+ *  on an underlying line layer. Since this is a controlled component, it does
+ *  not actually manage the hover state of each point or move points as they
+ *  are dragged— that responsibility is left up to a higher level component.
+ */
+const InteractiveLineLayer: React.FC<InteractiveLineLayerProps> = (props) => {
+  const {
+    onClick,
+    onHoverEnter,
+    onHoverLeave,
+    onDragStart,
+    onDragEnd,
+    onDrag,
+    eventHandlerPool,
+    eventHandlerPriority,
+  } = props;
+
+  // Flag set once the underlying point layer has been added to the map
+  const [lineLayerID, setLineLayerID] = useState<string | null>(null);
+  const { map } = useContext(MapboxContext);
+
+  // Connect event handlers to the map
+  useMapLayerInteractions({
+    map,
+    layerID: lineLayerID,
+    onClick,
+    onHoverEnter,
+    onHoverLeave,
+    onDragStart,
+    onDrag,
+    onDragEnd,
+    priority: eventHandlerPriority,
+    eventHandlerPool,
+  });
+
+  return <LineLayer {...props} onAdd={setLineLayerID} />;
+};
+
+export default InteractiveLineLayer;

--- a/src/components/layers/InteractivePointLayer/InteractivePointLayer.stories.tsx
+++ b/src/components/layers/InteractivePointLayer/InteractivePointLayer.stories.tsx
@@ -26,6 +26,14 @@ const mockPoints = [
   { id: "D", latitude: -5, longitude: -5 },
   { id: "E", latitude: 0, longitude: 0 },
 ];
+
+const mockPointsB = [
+  { id: "F", latitude: -10.5, longitude: -10.5 },
+  { id: "G", latitude: -10.5, longitude: -5.5 },
+  { id: "H", latitude: -5.5, longitude: -10 },
+  { id: "I", latitude: -5.5, longitude: -5 },
+  { id: "J", latitude: 0.5, longitude: 0.5 },
+];
 const bigMockPointsList = [];
 for (let i = -180; i < 180; i += 5) {
   for (let j = -90; j < 90; j += 5) {
@@ -70,13 +78,18 @@ const InteractivePointsStateManager: Story<
   const [points, setPoints] = useState(
     props.points.map((p) => ({
       ...p,
-      clickable: true,
-      hoverable: true,
-      draggable: props.draggable ?? false,
+
       // TODO: The layers could be re-written to use Mapbox `featureState`
       // instead of setting GeoJSON properties
       // See: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfeaturestate
-      properties: { selected: false, hovering: false },
+      properties: {
+        id: p.id,
+        selected: false,
+        hovering: false,
+        clickable: true,
+        hoverable: true,
+        draggable: props.draggable ?? false,
+      },
     }))
   );
 
@@ -165,6 +178,14 @@ const InteractivePointsStateManager: Story<
     />
   );
 };
+
+const Component = InteractivePointsStateManager as any;
+export const OverlappingLayers = () => (
+  <>
+    <Component points={mockPoints} />
+    <Component points={mockPointsB} />
+  </>
+);
 
 export const AFewPoints = InteractivePointsStateManager.bind({});
 AFewPoints.args = {

--- a/src/components/layers/InteractivePointLayer/InteractivePointLayer.stories.tsx
+++ b/src/components/layers/InteractivePointLayer/InteractivePointLayer.stories.tsx
@@ -20,24 +20,29 @@ export default {
 } as Meta;
 
 const mockPoints = [
-  { id: "A", latitude: -10, longitude: -10 },
-  { id: "B", latitude: -10, longitude: -5 },
-  { id: "C", latitude: -5, longitude: -10 },
-  { id: "D", latitude: -5, longitude: -5 },
-  { id: "E", latitude: 0, longitude: 0 },
+  { id: "A", latitude: -10, longitude: -10, properties: {} },
+  { id: "B", latitude: -10, longitude: -5, properties: {} },
+  { id: "C", latitude: -5, longitude: -10, properties: {} },
+  { id: "D", latitude: -5, longitude: -5, properties: {} },
+  { id: "E", latitude: 0, longitude: 0, properties: {} },
 ];
 
 const mockPointsB = [
-  { id: "F", latitude: -10.5, longitude: -10.5 },
-  { id: "G", latitude: -10.5, longitude: -5.5 },
-  { id: "H", latitude: -5.5, longitude: -10 },
-  { id: "I", latitude: -5.5, longitude: -5 },
-  { id: "J", latitude: 0.5, longitude: 0.5 },
+  { id: "F", latitude: -10.5, longitude: -10.5, properties: {} },
+  { id: "G", latitude: -10.5, longitude: -5.5, properties: {} },
+  { id: "H", latitude: -5.5, longitude: -10, properties: {} },
+  { id: "I", latitude: -5.5, longitude: -5, properties: {} },
+  { id: "J", latitude: 0.5, longitude: 0.5, properties: {} },
 ];
 const bigMockPointsList = [];
 for (let i = -180; i < 180; i += 5) {
   for (let j = -90; j < 90; j += 5) {
-    bigMockPointsList.push({ id: `${i}-${j}`, latitude: j, longitude: i });
+    bigMockPointsList.push({
+      id: `${i}-${j}`,
+      latitude: j,
+      longitude: i,
+      properties: {},
+    });
   }
 }
 
@@ -78,10 +83,6 @@ const InteractivePointsStateManager: Story<
   const [points, setPoints] = useState(
     props.points.map((p) => ({
       ...p,
-
-      // TODO: The layers could be re-written to use Mapbox `featureState`
-      // instead of setting GeoJSON properties
-      // See: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfeaturestate
       properties: {
         id: p.id,
         selected: false,
@@ -183,7 +184,7 @@ const Component = InteractivePointsStateManager as any;
 export const OverlappingLayers = () => (
   <>
     <Component points={mockPoints} />
-    <Component points={mockPointsB} />
+    <Component points={mockPointsB} priority={0} />
   </>
 );
 

--- a/src/components/layers/InteractivePointLayer/InteractivePointLayer.stories.tsx
+++ b/src/components/layers/InteractivePointLayer/InteractivePointLayer.stories.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useRef,
-  useContext,
-} from "react";
+import React, { useState, useCallback, useContext } from "react";
 
 import { Story, Meta } from "@storybook/react/types-6-0";
 
@@ -14,7 +8,6 @@ import InteractivePointLayer, {
 } from ".";
 import MapDecorator from "../../../storybook-helpers/map-decorator";
 
-import spotterImg from "../../../storybook-helpers/assets/spotter.png";
 import { MapboxMapContext } from "../../..";
 import PointLayer from "../PointLayer";
 
@@ -87,21 +80,12 @@ const InteractivePointsStateManager: Story<
     }))
   );
 
-  const handleDragStart = useCallback(
-    (
-      id: string | number,
-      offset: mapboxgl.Point,
-      e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-    ) => {},
-    []
-  );
+  const handleDragStart = useCallback(() => {}, []);
   const handleDragEnd = useCallback(() => {}, []);
   const handleDrag = useCallback(
     (
       id: string | number,
-      newLocation: { latitude: number; longitude: number },
-      offset: mapboxgl.Point,
-      e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+      newLocation: { latitude: number; longitude: number }
     ) => {
       if (!map) return;
 

--- a/src/components/layers/InteractivePointLayer/index.tsx
+++ b/src/components/layers/InteractivePointLayer/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useContext, useRef, useMemo } from "react";
 import { MapboxContext } from "../../MapboxMap";
 import PointLayer, { PointLayerProps } from "../PointLayer";
 import { LngLat } from "mapbox-gl";
+import useMapLayerInteractions from "../../../hooks/useMapInteractions";
 
 type MapEventHandler<TEvent = mapboxgl.MapMouseEvent> = (
   id: string | number,
@@ -75,179 +76,194 @@ const InteractivePointLayer: React.FC<InteractivePointLayerProps> = (props) => {
     onDrag,
   } = props;
 
-  // Index points by ID for fast lookup
-  const pointIndex = useMemo(
-    () =>
-      points.reduce((accum: Record<string, InteractivePointData>, p) => {
-        accum[p.id] = p;
-        return accum;
-      }, {}),
-    [points]
-  );
-
-  // Keep track of the last feature we were hovering over to trigger separate
-  // hoverEnter and hoverLeave events
-  const lastHoverId = useRef<string | number | null>(null);
-  const dragging = useRef<{
-    pointID: string | number;
-    offset: mapboxgl.Point;
-  } | null>(null);
-
   // Flag set once the underlying point layer has been added to the map
   const [pointLayerID, setPointLayerID] = useState<string | null>(null);
   const { map } = useContext(MapboxContext);
 
-  // Set up event handlers
-  useEffect(() => {
-    if (!map || pointLayerID === null) return;
-    const handleClick: NativeMapEventHandler = (e) => {
-      const id =
-        getPointsSortedByDistance(e)?.find((f) => {
-          if (f.id === null) return false;
-          const match = pointIndex[f.id];
-          return match && match.clickable;
-        })?.id ?? null;
-      if (id === undefined || id === null) return;
-
-      onClick?.(id, e);
-    };
-    // Handle hover events and drag events
-    const handleMouseMove: NativeMapEventHandler = (e) => {
-      // Don't do anything if we're currently dragging a point
-      if (dragging.current !== null) return;
-      const sortedFeatures = getPointsSortedByDistance(e);
-      const closestHoverableID =
-        sortedFeatures?.find((f) => {
-          if (f.id === null) return false;
-          const match = pointIndex[f.id];
-          return match && match.hoverable;
-        })?.id ?? null;
-
-      // Only fire hover events if the feature beneath the pointer has changed
-      if (closestHoverableID !== lastHoverId.current) {
-        if (lastHoverId.current !== null) {
-          onHoverLeave?.(lastHoverId.current, e);
-        }
-
-        if (closestHoverableID !== null) onHoverEnter?.(closestHoverableID, e);
-        lastHoverId.current = closestHoverableID;
-      }
-    };
-
-    const handleDrag: NativeMapEventHandler<
-      mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-    > = (e) => {
-      if ((e.originalEvent as TouchEvent).touches?.length > 1) {
-        e.preventDefault();
-        return;
-      }
-      // Fire a drag event if currently dragging anything
-      if (dragging.current !== null) {
-        const pointerProjected = map.project(e.lngLat);
-        const offsetLngLat = map.unproject(
-          pointerProjected.sub(dragging.current.offset)
-        );
-        onDrag?.(
-          dragging.current.pointID,
-          { longitude: offsetLngLat.lng, latitude: offsetLngLat.lat },
-          dragging.current.offset,
-          e
-        );
-      }
-    };
-
-    const handleMouseDown: NativeMapEventHandler<
-      mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-    > = (e) => {
-      // Don't handle a touchstart event if we're already dragging something
-      if (e.type === "touchstart" && dragging.current !== null) {
-        return;
-      }
-      const closestFeature = getPointsSortedByDistance(e)?.find((f) => {
-        if (f.id === null) return false;
-        const match = pointIndex[f.id];
-        return match && match.draggable;
-      });
-
-      const id = closestFeature?.id ?? null;
-
-      if (
-        id === null ||
-        !closestFeature ||
-        closestFeature.geometry?.type !== "Point"
-      )
-        return;
-
-      // Start a new drag event
-      const pointProjected = map.project(
-        closestFeature.geometry.coordinates as [number, number]
-      );
-      const pointerProjected = map.project(e.lngLat);
-      const offset = pointerProjected.sub(pointProjected);
-
-      dragging.current = { pointID: id, offset };
-
-      onDragStart?.(id, offset, e);
-      e.preventDefault();
-    };
-
-    const handleMouseUp = (e: any) => {
-      if (dragging.current === null) return;
-      onDragEnd?.(dragging.current.pointID, e);
-      dragging.current = null;
-
-      if (lastHoverId.current !== null) {
-        onHoverLeave?.(lastHoverId.current, e);
-        lastHoverId.current = null;
-      }
-    };
-
-    // Events for click and hover handlers
-    map.on("click", pointLayerID, handleClick);
-    map.on("mousemove", pointLayerID, handleMouseMove);
-    map.on("mouseleave", pointLayerID, handleMouseMove);
-
-    // Events for drag handlers
-    map.on("mousedown", pointLayerID, handleMouseDown);
-    map.on("mousemove", handleDrag);
-    map.on("mouseup", handleMouseUp);
-
-    map.on("touchstart", pointLayerID, handleMouseDown);
-    map.on("touchmove", handleDrag);
-    map.on("touchend", handleMouseUp);
-    map.on("touchcancel", handleMouseUp);
-
-    // Make sure to capture pointerup events anywhere in the window
-    window.addEventListener("pointerup", handleMouseUp);
-
-    // Clean up events when we're done
-    return () => {
-      map.off("click", pointLayerID, handleClick);
-      map.off("mousemove", pointLayerID, handleMouseMove);
-      map.off("mouseleave", pointLayerID, handleMouseMove);
-
-      map.off("mousedown", pointLayerID, handleMouseDown);
-      map.off("mousemove", handleDrag);
-      map.off("mouseup", handleMouseUp);
-
-      map.off("touchstart", pointLayerID, handleMouseDown);
-      map.off("touchmove", handleDrag);
-      map.off("touchend", handleMouseUp);
-      map.off("touchcancel", handleMouseUp);
-
-      window.removeEventListener("pointerup", handleMouseUp);
-    };
-  }, [
+  // Connect event handlers to the map
+  useMapLayerInteractions({
     map,
+    layerID: pointLayerID,
     onClick,
-    onDrag,
-    onDragEnd,
-    onDragStart,
     onHoverEnter,
     onHoverLeave,
-    pointIndex,
-    pointLayerID,
-  ]);
+    onDragStart,
+    onDrag,
+    onDragEnd,
+  });
+  // // Index points by ID for fast lookup
+  // const pointIndex = useMemo(
+  //   () =>
+  //     points.reduce((accum: Record<string, InteractivePointData>, p) => {
+  //       accum[p.id] = p;
+  //       return accum;
+  //     }, {}),
+  //   [points]
+  // );
+
+  // // Keep track of the last feature we were hovering over to trigger separate
+  // // hoverEnter and hoverLeave events
+  // const lastHoverId = useRef<string | number | null>(null);
+  // const dragging = useRef<{
+  //   pointID: string | number;
+  //   offset: mapboxgl.Point;
+  // } | null>(null);
+
+  // // Flag set once the underlying point layer has been added to the map
+  // const [pointLayerID, setPointLayerID] = useState<string | null>(null);
+  // const { map } = useContext(MapboxContext);
+
+  // // Set up event handlers
+  // useEffect(() => {
+  //   if (!map || pointLayerID === null) return;
+  //   const handleClick: NativeMapEventHandler = (e) => {
+  //     const id =
+  //       getPointsSortedByDistance(e)?.find((f) => {
+  //         if (f.id === null) return false;
+  //         const match = pointIndex[f.id];
+  //         return match && match.clickable;
+  //       })?.id ?? null;
+  //     if (id === undefined || id === null) return;
+
+  //     onClick?.(id, e);
+  //   };
+  //   // Handle hover events and drag events
+  //   const handleMouseMove: NativeMapEventHandler = (e) => {
+  //     // Don't do anything if we're currently dragging a point
+  //     if (dragging.current !== null) return;
+  //     const sortedFeatures = getPointsSortedByDistance(e);
+  //     const closestHoverableID =
+  //       sortedFeatures?.find((f) => {
+  //         if (f.id === null) return false;
+  //         const match = pointIndex[f.id];
+  //         return match && match.hoverable;
+  //       })?.id ?? null;
+
+  //     // Only fire hover events if the feature beneath the pointer has changed
+  //     if (closestHoverableID !== lastHoverId.current) {
+  //       if (lastHoverId.current !== null) {
+  //         onHoverLeave?.(lastHoverId.current, e);
+  //       }
+
+  //       if (closestHoverableID !== null) onHoverEnter?.(closestHoverableID, e);
+  //       lastHoverId.current = closestHoverableID;
+  //     }
+  //   };
+
+  //   const handleDrag: NativeMapEventHandler<
+  //     mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+  //   > = (e) => {
+  //     if ((e.originalEvent as TouchEvent).touches?.length > 1) {
+  //       e.preventDefault();
+  //       return;
+  //     }
+  //     // Fire a drag event if currently dragging anything
+  //     if (dragging.current !== null) {
+  //       const pointerProjected = map.project(e.lngLat);
+  //       const offsetLngLat = map.unproject(
+  //         pointerProjected.sub(dragging.current.offset)
+  //       );
+  //       onDrag?.(
+  //         dragging.current.pointID,
+  //         { longitude: offsetLngLat.lng, latitude: offsetLngLat.lat },
+  //         dragging.current.offset,
+  //         e
+  //       );
+  //     }
+  //   };
+
+  //   const handleMouseDown: NativeMapEventHandler<
+  //     mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+  //   > = (e) => {
+  //     // Don't handle a touchstart event if we're already dragging something
+  //     if (e.type === "touchstart" && dragging.current !== null) {
+  //       return;
+  //     }
+  //     const closestFeature = getPointsSortedByDistance(e)?.find((f) => {
+  //       if (f.id === null) return false;
+  //       const match = pointIndex[f.id];
+  //       return match && match.draggable;
+  //     });
+
+  //     const id = closestFeature?.id ?? null;
+
+  //     if (
+  //       id === null ||
+  //       !closestFeature ||
+  //       closestFeature.geometry?.type !== "Point"
+  //     )
+  //       return;
+
+  //     // Start a new drag event
+  //     const pointProjected = map.project(
+  //       closestFeature.geometry.coordinates as [number, number]
+  //     );
+  //     const pointerProjected = map.project(e.lngLat);
+  //     const offset = pointerProjected.sub(pointProjected);
+
+  //     dragging.current = { pointID: id, offset };
+
+  //     onDragStart?.(id, offset, e);
+  //     e.preventDefault();
+  //   };
+
+  //   const handleMouseUp = (e: any) => {
+  //     if (dragging.current === null) return;
+  //     onDragEnd?.(dragging.current.pointID, e);
+  //     dragging.current = null;
+
+  //     if (lastHoverId.current !== null) {
+  //       onHoverLeave?.(lastHoverId.current, e);
+  //       lastHoverId.current = null;
+  //     }
+  //   };
+
+  //   // Events for click and hover handlers
+  //   map.on("click", pointLayerID, handleClick);
+  //   map.on("mousemove", pointLayerID, handleMouseMove);
+  //   map.on("mouseleave", pointLayerID, handleMouseMove);
+
+  //   // Events for drag handlers
+  //   map.on("mousedown", pointLayerID, handleMouseDown);
+  //   map.on("mousemove", handleDrag);
+  //   map.on("mouseup", handleMouseUp);
+
+  //   map.on("touchstart", pointLayerID, handleMouseDown);
+  //   map.on("touchmove", handleDrag);
+  //   map.on("touchend", handleMouseUp);
+  //   map.on("touchcancel", handleMouseUp);
+
+  //   // Make sure to capture pointerup events anywhere in the window
+  //   window.addEventListener("pointerup", handleMouseUp);
+
+  //   // Clean up events when we're done
+  //   return () => {
+  //     map.off("click", pointLayerID, handleClick);
+  //     map.off("mousemove", pointLayerID, handleMouseMove);
+  //     map.off("mouseleave", pointLayerID, handleMouseMove);
+
+  //     map.off("mousedown", pointLayerID, handleMouseDown);
+  //     map.off("mousemove", handleDrag);
+  //     map.off("mouseup", handleMouseUp);
+
+  //     map.off("touchstart", pointLayerID, handleMouseDown);
+  //     map.off("touchmove", handleDrag);
+  //     map.off("touchend", handleMouseUp);
+  //     map.off("touchcancel", handleMouseUp);
+
+  //     window.removeEventListener("pointerup", handleMouseUp);
+  //   };
+  // }, [
+  //   map,
+  //   onClick,
+  //   onDrag,
+  //   onDragEnd,
+  //   onDragStart,
+  //   onHoverEnter,
+  //   onHoverLeave,
+  //   pointIndex,
+  //   pointLayerID,
+  // ]);
 
   return <PointLayer {...props} onAdd={setPointLayerID} />;
 };

--- a/src/components/layers/InteractivePointLayer/index.tsx
+++ b/src/components/layers/InteractivePointLayer/index.tsx
@@ -1,33 +1,16 @@
-import React, { useState, useEffect, useContext, useRef, useMemo } from "react";
+import React, { useState, useContext } from "react";
 
 import { MapboxContext } from "../../MapboxMap";
 import PointLayer, { PointLayerProps } from "../PointLayer";
-import { LngLat } from "mapbox-gl";
-import useMapLayerInteractions from "../../../hooks/useMapInteractions";
+import useMapLayerInteractions, {
+  InteractiveLayerProps,
+} from "../../../hooks/useMapInteractions";
 
-type MapEventHandler<TEvent = mapboxgl.MapMouseEvent> = (
-  id: string | number,
-  e: TEvent
-) => void;
-type NativeMapEventHandler<TEvent = mapboxgl.MapMouseEvent> = (
-  e: TEvent & {
-    features?: mapboxgl.MapboxGeoJSONFeature[] | undefined;
-  }
-) => void;
 export type InteractivePointData = {
   /** Unique ID for this point that will be passed to all interaction event
    *  handlers
    */
   id: string | number;
-
-  /** Flag indicating whether this point should respond to drag events */
-  draggable?: boolean;
-
-  /** Flag indicating whether this point should respond to click events */
-  clickable?: boolean;
-
-  /** Flag indicating whether this point should respond to hover events */
-  hoverable?: boolean;
 
   /** Latitude position of this point */
   latitude: number;
@@ -37,28 +20,22 @@ export type InteractivePointData = {
   /** Any data you want to make available to Mapbox style functions must go
    *  in the `properties` key
    */
-  properties?: GeoJSON.GeoJsonProperties;
+  properties: GeoJSON.GeoJsonProperties & {
+    /** Flag indicating whether this point should respond to drag events */
+    draggable?: boolean;
+
+    /** Flag indicating whether this point should respond to click events */
+    clickable?: boolean;
+
+    /** Flag indicating whether this point should respond to hover events */
+    hoverable?: boolean;
+  };
 };
 
-export type InteractivePointLayerProps = PointLayerProps & {
-  points: InteractivePointData[];
-
-  onClick?: MapEventHandler;
-  onHoverEnter?: MapEventHandler;
-  onHoverLeave?: MapEventHandler;
-  onDragStart?: (
-    id: string | number,
-    offset: mapboxgl.Point,
-    e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-  ) => void;
-  onDrag?: (
-    id: string | number,
-    newCoordinates: { longitude: number; latitude: number },
-    offset: mapboxgl.Point,
-    e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-  ) => void;
-  onDragEnd?: MapEventHandler;
-};
+export type InteractivePointLayerProps = PointLayerProps &
+  InteractiveLayerProps & {
+    points: InteractivePointData[];
+  };
 
 /** A controlled component that fires the appropriate callback for user events
  *  on an underlying point layer. Since this is a controlled component, it does
@@ -67,13 +44,14 @@ export type InteractivePointLayerProps = PointLayerProps & {
  */
 const InteractivePointLayer: React.FC<InteractivePointLayerProps> = (props) => {
   const {
-    points,
     onClick,
     onHoverEnter,
     onHoverLeave,
     onDragStart,
     onDragEnd,
     onDrag,
+    eventHandlerPool,
+    eventHandlerPriority,
   } = props;
 
   // Flag set once the underlying point layer has been added to the map
@@ -90,213 +68,11 @@ const InteractivePointLayer: React.FC<InteractivePointLayerProps> = (props) => {
     onDragStart,
     onDrag,
     onDragEnd,
+    priority: eventHandlerPriority,
+    eventHandlerPool,
   });
-  // // Index points by ID for fast lookup
-  // const pointIndex = useMemo(
-  //   () =>
-  //     points.reduce((accum: Record<string, InteractivePointData>, p) => {
-  //       accum[p.id] = p;
-  //       return accum;
-  //     }, {}),
-  //   [points]
-  // );
-
-  // // Keep track of the last feature we were hovering over to trigger separate
-  // // hoverEnter and hoverLeave events
-  // const lastHoverId = useRef<string | number | null>(null);
-  // const dragging = useRef<{
-  //   pointID: string | number;
-  //   offset: mapboxgl.Point;
-  // } | null>(null);
-
-  // // Flag set once the underlying point layer has been added to the map
-  // const [pointLayerID, setPointLayerID] = useState<string | null>(null);
-  // const { map } = useContext(MapboxContext);
-
-  // // Set up event handlers
-  // useEffect(() => {
-  //   if (!map || pointLayerID === null) return;
-  //   const handleClick: NativeMapEventHandler = (e) => {
-  //     const id =
-  //       getPointsSortedByDistance(e)?.find((f) => {
-  //         if (f.id === null) return false;
-  //         const match = pointIndex[f.id];
-  //         return match && match.clickable;
-  //       })?.id ?? null;
-  //     if (id === undefined || id === null) return;
-
-  //     onClick?.(id, e);
-  //   };
-  //   // Handle hover events and drag events
-  //   const handleMouseMove: NativeMapEventHandler = (e) => {
-  //     // Don't do anything if we're currently dragging a point
-  //     if (dragging.current !== null) return;
-  //     const sortedFeatures = getPointsSortedByDistance(e);
-  //     const closestHoverableID =
-  //       sortedFeatures?.find((f) => {
-  //         if (f.id === null) return false;
-  //         const match = pointIndex[f.id];
-  //         return match && match.hoverable;
-  //       })?.id ?? null;
-
-  //     // Only fire hover events if the feature beneath the pointer has changed
-  //     if (closestHoverableID !== lastHoverId.current) {
-  //       if (lastHoverId.current !== null) {
-  //         onHoverLeave?.(lastHoverId.current, e);
-  //       }
-
-  //       if (closestHoverableID !== null) onHoverEnter?.(closestHoverableID, e);
-  //       lastHoverId.current = closestHoverableID;
-  //     }
-  //   };
-
-  //   const handleDrag: NativeMapEventHandler<
-  //     mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-  //   > = (e) => {
-  //     if ((e.originalEvent as TouchEvent).touches?.length > 1) {
-  //       e.preventDefault();
-  //       return;
-  //     }
-  //     // Fire a drag event if currently dragging anything
-  //     if (dragging.current !== null) {
-  //       const pointerProjected = map.project(e.lngLat);
-  //       const offsetLngLat = map.unproject(
-  //         pointerProjected.sub(dragging.current.offset)
-  //       );
-  //       onDrag?.(
-  //         dragging.current.pointID,
-  //         { longitude: offsetLngLat.lng, latitude: offsetLngLat.lat },
-  //         dragging.current.offset,
-  //         e
-  //       );
-  //     }
-  //   };
-
-  //   const handleMouseDown: NativeMapEventHandler<
-  //     mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
-  //   > = (e) => {
-  //     // Don't handle a touchstart event if we're already dragging something
-  //     if (e.type === "touchstart" && dragging.current !== null) {
-  //       return;
-  //     }
-  //     const closestFeature = getPointsSortedByDistance(e)?.find((f) => {
-  //       if (f.id === null) return false;
-  //       const match = pointIndex[f.id];
-  //       return match && match.draggable;
-  //     });
-
-  //     const id = closestFeature?.id ?? null;
-
-  //     if (
-  //       id === null ||
-  //       !closestFeature ||
-  //       closestFeature.geometry?.type !== "Point"
-  //     )
-  //       return;
-
-  //     // Start a new drag event
-  //     const pointProjected = map.project(
-  //       closestFeature.geometry.coordinates as [number, number]
-  //     );
-  //     const pointerProjected = map.project(e.lngLat);
-  //     const offset = pointerProjected.sub(pointProjected);
-
-  //     dragging.current = { pointID: id, offset };
-
-  //     onDragStart?.(id, offset, e);
-  //     e.preventDefault();
-  //   };
-
-  //   const handleMouseUp = (e: any) => {
-  //     if (dragging.current === null) return;
-  //     onDragEnd?.(dragging.current.pointID, e);
-  //     dragging.current = null;
-
-  //     if (lastHoverId.current !== null) {
-  //       onHoverLeave?.(lastHoverId.current, e);
-  //       lastHoverId.current = null;
-  //     }
-  //   };
-
-  //   // Events for click and hover handlers
-  //   map.on("click", pointLayerID, handleClick);
-  //   map.on("mousemove", pointLayerID, handleMouseMove);
-  //   map.on("mouseleave", pointLayerID, handleMouseMove);
-
-  //   // Events for drag handlers
-  //   map.on("mousedown", pointLayerID, handleMouseDown);
-  //   map.on("mousemove", handleDrag);
-  //   map.on("mouseup", handleMouseUp);
-
-  //   map.on("touchstart", pointLayerID, handleMouseDown);
-  //   map.on("touchmove", handleDrag);
-  //   map.on("touchend", handleMouseUp);
-  //   map.on("touchcancel", handleMouseUp);
-
-  //   // Make sure to capture pointerup events anywhere in the window
-  //   window.addEventListener("pointerup", handleMouseUp);
-
-  //   // Clean up events when we're done
-  //   return () => {
-  //     map.off("click", pointLayerID, handleClick);
-  //     map.off("mousemove", pointLayerID, handleMouseMove);
-  //     map.off("mouseleave", pointLayerID, handleMouseMove);
-
-  //     map.off("mousedown", pointLayerID, handleMouseDown);
-  //     map.off("mousemove", handleDrag);
-  //     map.off("mouseup", handleMouseUp);
-
-  //     map.off("touchstart", pointLayerID, handleMouseDown);
-  //     map.off("touchmove", handleDrag);
-  //     map.off("touchend", handleMouseUp);
-  //     map.off("touchcancel", handleMouseUp);
-
-  //     window.removeEventListener("pointerup", handleMouseUp);
-  //   };
-  // }, [
-  //   map,
-  //   onClick,
-  //   onDrag,
-  //   onDragEnd,
-  //   onDragStart,
-  //   onHoverEnter,
-  //   onHoverLeave,
-  //   pointIndex,
-  //   pointLayerID,
-  // ]);
 
   return <PointLayer {...props} onAdd={setPointLayerID} />;
-};
-
-/** Given a Mapbox `MapMouseEvent`, sort any point features that the event
- *  involves by their distance to the mouse in ascending order.
- *
- *  Mapbox doesn't have any native concept of event capturing, so the event it
- *  fires will list out all the features that are hit. We most likely only want
- *  to get the one closest to the mouse event.
- */
-const getPointsSortedByDistance = (
-  e: (mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent) & {
-    features?: mapboxgl.MapboxGeoJSONFeature[] | undefined;
-  } & mapboxgl.EventData
-) => {
-  const features = e.features;
-  if (!features) return null;
-  const eventPoint = e.lngLat;
-
-  return features
-    .map((f) => ({
-      ...f,
-      id: (f.properties?.["id"] as number | string) ?? null,
-      geometry: f.geometry, // This is a getter and needs to be manually copied
-      distance:
-        f.geometry.type === "Point"
-          ? eventPoint.distanceTo(
-              new LngLat(f.geometry.coordinates[0], f.geometry.coordinates[1])
-            )
-          : Infinity,
-    }))
-    .sort((a, b) => a.distance - b.distance);
 };
 
 export default InteractivePointLayer;

--- a/src/components/layers/LineLayer/LineLayer.stories.tsx
+++ b/src/components/layers/LineLayer/LineLayer.stories.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+
+import { Story, Meta } from "@storybook/react/types-6-0";
+
+import LineLayer, { LineLayerProps } from ".";
+import MapDecorator from "../../../storybook-helpers/map-decorator";
+export default {
+  title: "Line layer",
+  component: LineLayer,
+  argTypes: {},
+  args: {},
+  decorators: [MapDecorator()],
+} as Meta;
+
+const mockLines = [
+  {
+    id: "A",
+    coordinates: [
+      [-27, -6],
+      [-21, 0],
+      [-15, -8],
+      [-9, -0],
+      [-3, -8],
+      [1, -1],
+      [8, -8],
+    ],
+    properties: {
+      color: "#ff55ff",
+    },
+  },
+  {
+    id: "B",
+    coordinates: [
+      [-22.4, 27.7],
+      [-26.2, 21.8],
+      [-27.8, 18.3],
+      [-27.9, 13.7],
+      [-26.2, 9.5],
+      [-22.7, 6.5],
+      [-18.7, 4.3],
+      [-14.2, 3.4],
+      [-9.8, 1.6],
+      [-8.8, -1.7],
+      [-9.8, -4.7],
+      [-10.6, -8.8],
+      [-13.2, -14],
+      [-17.9, -20.2],
+      [-17.7, -23.3],
+      [-15.3, -25.3],
+      [-9.4, -28.4],
+      [-6.1, -29.5],
+      [-1.1, -30.8],
+      [4.6, -31.2],
+      [8, -30.3],
+    ],
+    properties: {
+      color: "#55FF55",
+    },
+  },
+  {
+    id: "C",
+    coordinates: [
+      [-29.1, 5.2],
+      [-31.2, 2.3],
+      [-31.6, -2.8],
+      [-28.1, -4],
+      [-21.6, -4.2],
+      [-19.7, -0.9],
+      [-20, 1.9],
+      [-23.4, 3.8],
+      [-25.1, 3.8],
+      [-28.3, 2],
+      [-28.2, -1],
+      [-26.9, -2.2],
+      [-23.7, -2],
+      [-22.1, -0.6],
+      [-22.5, 0.8],
+      [-24.2, 1.9],
+      [-25.1, 1.5],
+      [-25.8, -0.2],
+      [-24.8, -0.4],
+      [-23.9, 0.2],
+    ],
+    properties: {
+      color: "#00DDDD",
+    },
+  },
+];
+const lineStyle: {
+  layout: mapboxgl.LineLayout;
+  paint: mapboxgl.LinePaint;
+} = {
+  layout: {},
+  paint: {
+    "line-color": ["get", "color"],
+    "line-width": 4,
+  },
+};
+
+const Template: Story<LineLayerProps> = (args) => <LineLayer {...args} />;
+
+export const SingleLine = Template.bind({});
+SingleLine.args = {
+  lines: mockLines.slice(0, 1),
+  style: lineStyle,
+};
+
+export const MultipleLines = Template.bind({});
+MultipleLines.args = {
+  lines: mockLines,
+  style: lineStyle,
+};

--- a/src/components/layers/LineLayer/index.tsx
+++ b/src/components/layers/LineLayer/index.tsx
@@ -3,12 +3,17 @@ import { MapboxContext } from "../../MapboxMap";
 import { featureCollection, lineString, Position } from "@turf/helpers";
 import useMapLayer from "../../../hooks/useMapLayer";
 
-export type LineCoordinates = (Position | { latitude: number; longitude: number })[];
+export type LineCoordinates = (
+  | Position
+  | { latitude: number; longitude: number }
+)[];
 export type LineLayerProps = {
   lines:
     | {
         id: string | number;
-        coordinates: LineCoordinates,
+        coordinates: LineCoordinates;
+        properties: GeoJSON.GeoJsonProperties;
+      }[]
     | GeoJSON.FeatureCollection<GeoJSON.LineString | GeoJSON.MultiLineString>;
 
   style: {

--- a/src/components/layers/LineLayer/index.tsx
+++ b/src/components/layers/LineLayer/index.tsx
@@ -1,36 +1,68 @@
-import React, { useEffect, useContext } from "react";
-import MapboxContext from "../../../contexts/MapboxContext";
+import React, { useContext, useRef, useMemo } from "react";
+import { MapboxContext } from "../../MapboxMap";
+import { featureCollection, lineString, Position } from "@turf/helpers";
+import useMapLayer from "../../../hooks/useMapLayer";
 
-const LineLayer: React.FC<{
-  line: GeoJSON.Feature | GeoJSON.FeatureCollection;
-  color?: string;
-  width?: number;
+export type LineCoordinates = (Position | { latitude: number; longitude: number })[];
+export type LineLayerProps = {
+  lines:
+    | {
+        id: string | number;
+        coordinates: LineCoordinates,
+    | GeoJSON.FeatureCollection<GeoJSON.LineString | GeoJSON.MultiLineString>;
+
+  style: {
+    layout: mapboxgl.LineLayout;
+    paint: mapboxgl.LinePaint;
+  };
+
+  /** Callback fired after the layer has been added to the map. Useful if you
+   *  want to register event handlers after the layer is ready.
+   */
+  onAdd?: (layerName: string) => void;
+
   id?: string;
-}> = ({ line, color = "white", width = 1, id = "line" }) => {
+};
+
+// Used to generate unique layer and source IDs if one is not provided
+let idIncrement = 0;
+
+const LineLayer: React.FC<LineLayerProps> = ({
+  lines,
+  style,
+  onAdd,
+  id: _id,
+}) => {
+  const id = useRef(`line-layer-${++idIncrement}`);
+  if (_id) id.current = _id;
+
   const { map } = useContext(MapboxContext);
 
-  useEffect(() => {
-    if (!map) return;
-    const source = map.getSource(id);
-    if (source && source.type === "geojson") {
-      source.setData(line);
-    } else {
-      map.addSource(id, { type: "geojson", data: line });
-      map.addLayer({
-        id,
-        source: id,
-        type: "line",
-        paint: {
-          "line-color": color,
-          "line-width": width,
-        },
-      });
-    }
-    return () => {
-      map.removeLayer(id);
-      map.removeSource(id);
-    };
-  }, [line, map, id, width, color]);
+  // Create a geojson object for the source data
+  const geojson = useMemo(
+    () =>
+      "type" in lines
+        ? lines
+        : featureCollection(
+            lines.map((p) =>
+              lineString(
+                p.coordinates.map((c) =>
+                  "longitude" in c ? [c.longitude, c.latitude] : c
+                ),
+                {
+                  ...p.properties,
+                  id: p.id,
+                }
+              )
+            )
+          ),
+    [lines]
+  );
+
+  // This hook handles creating and updating layers on the Mapbox map for us
+  useMapLayer(map, id.current, "line", geojson, style, onAdd);
+
+  // No DOM output
   return null;
 };
 

--- a/src/hooks/useMapInteractions.ts
+++ b/src/hooks/useMapInteractions.ts
@@ -1,4 +1,5 @@
 import { useRef, useEffect } from "react";
+import { LngLat } from "mapbox-gl";
 
 export type InteractiveBaseType = {
   /** Unique ID for this element that will be passed to all interaction event
@@ -31,13 +32,21 @@ export type NativeMapEventHandler<TEvent = mapboxgl.MapMouseEvent> = (
   }
 ) => void;
 
-type NativeMapEventListener = <T extends keyof mapboxgl.MapLayerEventType>(
-  ev: mapboxgl.MapLayerEventType[T] & mapboxgl.EventData
+export type MapDragStartHandler = (
+  id: string | number,
+  offset: mapboxgl.Point,
+  e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+) => void;
+export type MapDragHandler = (
+  id: string | number,
+  newCoordinates: { longitude: number; latitude: number },
+  offset: mapboxgl.Point,
+  e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
 ) => void;
 
 type MapInteractionHandlerOptions = {
   map: mapboxgl.Map | null;
-  layerID: string;
+  layerID: string | null;
 
   /** An interaction pool can be used to ensure that only one event handler
    *  is fired even if multiple elements on multiple layers are hit by a
@@ -68,48 +77,314 @@ type MapInteractionHandlerOptions = {
   onDragEnd?: MapEventHandler;
 };
 
-// Pool structure is mapboxMap -> poolName -> layerName -> layerEventHandler
-const interactionPools = new Map<
-  mapboxgl.Map,
-  Map<
-    string,
-    {
-      disambiguationListener: NativeMapEventListener;
-      layerHandlers: Map<string, MapEventHandler>;
+type InteractionPoolLayerDefinition = {
+  id: string;
+  priority: number;
+  onClick?: MapEventHandler;
+  onHoverLeave?: MapEventHandler;
+  onHoverEnter?: MapEventHandler;
+  onDrag?: MapDragHandler;
+  onDragStart?: MapDragStartHandler;
+  onDragEnd?: MapEventHandler;
+};
+
+class MapboxEventHandlerPool {
+  private layers: InteractionPoolLayerDefinition[];
+  private lastHoverFeature: mapboxgl.MapboxGeoJSONFeature | null = null;
+  private dragging: {
+    feature: mapboxgl.MapboxGeoJSONFeature;
+    offset: mapboxgl.Point;
+  } | null = null;
+
+  private registered = false;
+
+  constructor(private map: mapboxgl.Map, private name: string) {
+    this.map = map;
+    this.layers = [];
+    this.register();
+  }
+
+  public register() {
+    // Register event listeners on creation
+    // Events for click and hover handlers
+    this.map.on("click", this.onClick);
+    this.map.on("mousemove", this.onMouseMove);
+    this.map.on("mouseleave", this.onMouseMove);
+
+    // Events for drag handlers
+    this.map.on("mousedown", this.onMouseDown);
+    this.map.on("mousemove", this.onDrag);
+    this.map.on("mouseup", this.onMouseUp);
+
+    this.map.on("touchstart", this.onMouseDown);
+    this.map.on("touchmove", this.onDrag);
+    this.map.on("touchend", this.onMouseUp);
+    this.map.on("touchcancel", this.onMouseUp);
+
+    // Make sure to capture pointerup events anywhere in the window
+    window.addEventListener("pointerup", this.onMouseUp);
+    this.registered = true;
+  }
+
+  public unregister() {
+    // Clean up events when we're done
+    this.map.off("click", this.onClick);
+    this.map.off("mousemove", this.onMouseMove);
+    this.map.off("mouseleave", this.onMouseMove);
+
+    // Events for drag handlers
+    this.map.off("mousedown", this.onMouseDown);
+    this.map.off("mousemove", this.onDrag);
+    this.map.off("mouseup", this.onMouseUp);
+
+    this.map.off("touchstart", this.onMouseDown);
+    this.map.off("touchmove", this.onDrag);
+    this.map.off("touchend", this.onMouseUp);
+    this.map.off("touchcancel", this.onMouseUp);
+
+    // Make sure to capture pointerup events anywhere in the window
+    window.removeEventListener("pointerup", this.onMouseUp);
+
+    this.registered = false;
+  }
+
+  public onClick: NativeMapEventHandler<mapboxgl.MapMouseEvent> = (e) => {
+    // Find the highest-ranked clickable feature
+    const highestPriorityClickableFeature =
+      this.sortEventFeatures(e)?.find((f) => {
+        if (f.properties?.id === null) return false;
+        return !!f.properties?.clickable;
+      }) ?? null;
+
+    if (
+      highestPriorityClickableFeature === null ||
+      highestPriorityClickableFeature.properties?.id === undefined ||
+      highestPriorityClickableFeature.properties?.id === null
+    )
+      return;
+
+    // Call the appropriate layer's registered onClick handler
+    this.layers
+      .find((l) => l.id === highestPriorityClickableFeature.layer.id)
+      ?.onClick?.(highestPriorityClickableFeature.properties.id, e);
+  };
+
+  // Handle hover events and drag events
+  public onMouseMove: NativeMapEventHandler = (e) => {
+    // Don't do anything if we're currently dragging a point
+    if (this.dragging !== null) return;
+    const sortedFeatures = this.sortEventFeatures(e);
+    const highestPriorityHoverableFeature =
+      sortedFeatures?.find((f) => {
+        if (f.properties?.id === null || f.properties?.id === undefined)
+          return false;
+        return !!f.properties?.hoverable;
+      }) ?? null;
+
+    // Only fire hover events if the feature beneath the pointer has changed
+    if (
+      highestPriorityHoverableFeature?.properties?.id !==
+      this.lastHoverFeature?.properties?.id
+    ) {
+      // Call the appropriate layer's registered onHoverLeave handler
+      if (!!this.lastHoverFeature?.properties?.id) {
+        this.layers
+          .find((l) => l.id === this.lastHoverFeature?.layer.id)
+          ?.onHoverLeave?.(this.lastHoverFeature.properties?.id, e);
+      }
+
+      if (!!highestPriorityHoverableFeature?.properties?.id) {
+        this.layers
+          .find((l) => l.id === highestPriorityHoverableFeature.layer.id)
+          ?.onHoverEnter?.(highestPriorityHoverableFeature.properties?.id, e);
+      }
+      this.lastHoverFeature = highestPriorityHoverableFeature;
     }
-  >
+  };
+
+  public onDrag: NativeMapEventHandler<
+    mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+  > = (e) => {
+    if ((e.originalEvent as TouchEvent).touches?.length > 1) {
+      e.preventDefault();
+      return;
+    }
+    // Fire a drag event if currently dragging anything
+    if (this.dragging !== null) {
+      const pointerProjected = this.map.project(e.lngLat);
+      const offsetLngLat = this.map.unproject(
+        pointerProjected.sub(this.dragging.offset)
+      );
+
+      if (this.dragging.feature.properties?.id === undefined) return;
+
+      // Fire event on appropriate layer's onDrag handler
+      this.layers
+        .find((l) => l.id === this.dragging?.feature.layer.id)
+        ?.onDrag?.(
+          this.dragging.feature.properties?.id,
+          { longitude: offsetLngLat.lng, latitude: offsetLngLat.lat },
+          this.dragging.offset,
+          e
+        );
+    }
+  };
+
+  public onMouseDown: NativeMapEventHandler<
+    mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+  > = (e) => {
+    // Don't handle a touchstart event if we're already dragging something
+    if (e.type === "touchstart" && this.dragging !== null) {
+      return;
+    }
+
+    // Find the highest-ranked clickable feature
+    const highestPriorityDragableFeature =
+      this.sortEventFeatures(e)?.find((f) => {
+        if (f.properties?.id === null) return false;
+        return !!f.properties?.draggable;
+      }) ?? null;
+
+    const id = highestPriorityDragableFeature?.properties?.id ?? null;
+
+    if (
+      id === null ||
+      !highestPriorityDragableFeature ||
+      highestPriorityDragableFeature.geometry?.type !== "Point"
+    )
+      return;
+
+    // Start a new drag event
+    const pointProjected = this.map.project(
+      highestPriorityDragableFeature.geometry.coordinates as [number, number]
+    );
+    const pointerProjected = this.map.project(e.lngLat);
+    const offset = pointerProjected.sub(pointProjected);
+
+    this.dragging = { feature: highestPriorityDragableFeature, offset };
+
+    // Fire event on appropriate layer's onDragStart handler
+    this.layers
+      .find((l) => l.id === highestPriorityDragableFeature.layer.id)
+      ?.onDragStart?.(
+        highestPriorityDragableFeature.properties?.id!,
+        offset,
+        e
+      );
+    e.preventDefault();
+  };
+
+  public onMouseUp = (e: any) => {
+    if (this.dragging === null) return;
+
+    // Fire event on appropriate layer's onDragEnd handler
+    this.layers
+      .find((l) => l.id === this.dragging?.feature.layer.id)
+      ?.onDragEnd?.(this.dragging.feature.properties?.id!, e);
+
+    this.dragging = null;
+
+    // Fire event on appropriate layer's onHoverLeave handler
+    if (this.lastHoverFeature !== null) {
+      this.layers
+        .find((l) => l.id === this.lastHoverFeature?.layer.id)
+        ?.onHoverLeave?.(this.lastHoverFeature.properties?.id!, e);
+
+      this.lastHoverFeature = null;
+    }
+  };
+
+  public addLayerListeners(listeners: InteractionPoolLayerDefinition) {
+    // See if there's a match
+    const matchIdx = this.layers.findIndex((l) => l.id === listeners.id);
+    if (matchIdx === -1) {
+      // Add a new layer definition if none exists
+      this.layers.push(listeners);
+    } else {
+      // Otherwise, merge definitions
+      this.layers[matchIdx] = { ...this.layers[matchIdx], ...listeners };
+    }
+
+    // Re-register map event handlers if needed
+    if (!this.registered) this.register();
+  }
+  public removeLayerListeners(layerID: string) {
+    this.layers = this.layers.filter((l) => l.id !== layerID);
+
+    // Unregister map event handlers when no layers are listening
+    if (this.layers.length === 0) this.unregister();
+  }
+
+  /** Sort features according to layer priority order as well as distance to
+   *  each feature
+   */
+  private sortEventFeatures(
+    e: (mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent) & mapboxgl.EventData
+  ) {
+    const features = this.map.queryRenderedFeatures(e.point, {
+      layers: this.layers.map((l) => l.id),
+    });
+    // Sort features by layer priority, then by distance to the features
+    const featuresByLayer = this.layers
+      .sort((a, b) => a.priority - b.priority)
+      .map(({ id, priority }) => ({
+        layerID: id,
+        priority,
+        features:
+          features
+            ?.filter((f) => f.layer.id === id)
+            .sort(
+              (a, b) =>
+                getDistanceToFeature(e.lngLat, a) -
+                getDistanceToFeature(e.lngLat, b)
+            ) ?? [],
+      }));
+
+    return featuresByLayer.flatMap((f) => f.features);
+  }
+}
+
+function getDistanceToFeature(
+  eventPoint: LngLat,
+  f: mapboxgl.MapboxGeoJSONFeature
+) {
+  // Distance to feature is only really meaningful for `Point` features.
+  // Otherwise, look to the feature's `priority` value if it exists
+  // And finally, fall back to using a `0` distance, meaning disambiguation will
+  // just use whichever feature occurs first
+  if (f.geometry.type === "Point") {
+    return eventPoint.distanceTo(
+      new LngLat(f.geometry.coordinates[0], f.geometry.coordinates[1])
+    );
+  } else return f.properties?.priority ?? 0;
+}
+
+/** A singleton mapping of event handler pools for each Mapbox Map */
+const eventHandlerPools = new Map<
+  mapboxgl.Map,
+  Map<string, MapboxEventHandlerPool>
 >();
-const getPoolLayers = (map: mapboxgl.Map, poolName: string) =>
-  interactionPools.get(map)?.get(poolName) ?? [];
 
-const addToPool = (
+/** Gets an event handler pool with the given name on the given Mapbox GL map.
+ *  Creates the pool if it doesn't already exist.
+ */
+function getEventHandlerPool(
   map: mapboxgl.Map,
-  poolName: string,
-  layerID: string,
-  handler: MapEventHandler
-) => {
-  // Create pools for this mapbox map if they don't already exist
-  if (!interactionPools.get(map)) {
-    interactionPools.set(map, new Map());
+  poolName: string
+): MapboxEventHandlerPool {
+  // Create the pool if it doesn't already exist
+  if (!eventHandlerPools.get(map)) {
+    eventHandlerPools.set(map, new Map());
   }
-
-  // Create the pool on the mapbox map if it doesn't already exist
-  if (!interactionPools.get(map)?.get(poolName)) {
-    interactionPools.get(map)?.set(poolName, new Map());
+  if (!eventHandlerPools.get(map)?.get(poolName)) {
+    eventHandlerPools
+      .get(map)!
+      .set(poolName, new MapboxEventHandlerPool(map, poolName));
   }
+  return eventHandlerPools.get(map)!.get(poolName)!;
+}
 
-  // Set a new handler for this layer in this pool on this mapbox map
-  interactionPools.get(map)?.get(poolName)?.set(layerID, handler);
-};
-
-const removeFromPool = (
-  map: mapboxgl.Map,
-  poolName: string,
-  layerID: string
-) => {
-  interactionPools.get(map)?.get(poolName)?.delete(layerID);
-};
-
+let poolAutoId = 0;
 const useMapLayerInteractions = ({
   map,
   layerID,
@@ -124,23 +399,41 @@ const useMapLayerInteractions = ({
 }: MapInteractionHandlerOptions) => {
   const poolId = useRef(poolAutoId++);
   let interactionPool = _interactionPool;
-  if (!_interactionPool) interactionPool = `auto-pool-${poolId.current}`;
+  //   if (!_interactionPool) interactionPool = `auto-pool-${poolId.current}`;
+  if (!_interactionPool) interactionPool = `shared-event-pool`;
 
-  // Update the interaction pool membership list whenever the layerID or
-  // interactionPool ID change
+  // Update the interaction pool whenever the parameters to this hook change
   useEffect(() => {
-    if (!map || !interactionPool) return;
-    addToPool(map, interactionPool, layerID);
+    if (!map || !interactionPool || !layerID) return;
 
-    // Capture values and clean up
-    const addedMap = map;
-    const addedPool = interactionPool;
-    const addedLayerID = layerID;
+    const pool = getEventHandlerPool(map, interactionPool);
+
+    pool.addLayerListeners({
+      id: layerID,
+      priority: priority ?? Infinity,
+      onClick,
+      onHoverEnter,
+      onHoverLeave,
+      onDragStart,
+      onDrag,
+      onDragEnd,
+    });
+
     return () => {
-      removeFromPool(addedMap, addedPool, addedLayerID);
+      pool.removeLayerListeners(layerID);
     };
-  }, [layerID, interactionPool, map]);
-
-  const poolLayers =
-    map && interactionPool ? getPoolLayers(map, interactionPool) : [];
+  }, [
+    layerID,
+    interactionPool,
+    map,
+    priority,
+    onClick,
+    onHoverEnter,
+    onHoverLeave,
+    onDragStart,
+    onDrag,
+    onDragEnd,
+  ]);
 };
+
+export default useMapLayerInteractions;

--- a/src/hooks/useMapInteractions.ts
+++ b/src/hooks/useMapInteractions.ts
@@ -1,0 +1,146 @@
+import { useRef, useEffect } from "react";
+
+export type InteractiveBaseType = {
+  /** Unique ID for this element that will be passed to all interaction event
+   *  handlers
+   */
+  id: string | number;
+
+  /** Flag indicating whether this element should respond to drag events */
+  draggable?: boolean;
+
+  /** Flag indicating whether this element should respond to click events */
+  clickable?: boolean;
+
+  /** Flag indicating whether this element should respond to hover events */
+  hoverable?: boolean;
+
+  /** Any data you want to make available to Mapbox style functions must go
+   *  in the `properties` key
+   */
+  properties?: GeoJSON.GeoJsonProperties;
+};
+
+export type MapEventHandler<TEvent = mapboxgl.MapMouseEvent> = (
+  id: string | number,
+  e: TEvent
+) => void;
+export type NativeMapEventHandler<TEvent = mapboxgl.MapMouseEvent> = (
+  e: TEvent & {
+    features?: mapboxgl.MapboxGeoJSONFeature[] | undefined;
+  }
+) => void;
+
+type NativeMapEventListener = <T extends keyof mapboxgl.MapLayerEventType>(
+  ev: mapboxgl.MapLayerEventType[T] & mapboxgl.EventData
+) => void;
+
+type MapInteractionHandlerOptions = {
+  map: mapboxgl.Map | null;
+  layerID: string;
+
+  /** An interaction pool can be used to ensure that only one event handler
+   *  is fired even if multiple elements on multiple layers are hit by a
+   *  single interaction.
+   */
+  interactionPool?: string;
+  /** When using an interaction pool, the `priority` is used to give
+   *  preference to certain layers, regardless of their draw order. Higher
+   *  priority values will claim the interaction event before elements with
+   *  lower priority values.
+   */
+  priority?: number;
+
+  onClick?: MapEventHandler;
+  onHoverEnter?: MapEventHandler;
+  onHoverLeave?: MapEventHandler;
+  onDragStart?: (
+    id: string | number,
+    offset: mapboxgl.Point,
+    e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+  ) => void;
+  onDrag?: (
+    id: string | number,
+    newCoordinates: { longitude: number; latitude: number },
+    offset: mapboxgl.Point,
+    e: mapboxgl.MapMouseEvent | mapboxgl.MapTouchEvent
+  ) => void;
+  onDragEnd?: MapEventHandler;
+};
+
+// Pool structure is mapboxMap -> poolName -> layerName -> layerEventHandler
+const interactionPools = new Map<
+  mapboxgl.Map,
+  Map<
+    string,
+    {
+      disambiguationListener: NativeMapEventListener;
+      layerHandlers: Map<string, MapEventHandler>;
+    }
+  >
+>();
+const getPoolLayers = (map: mapboxgl.Map, poolName: string) =>
+  interactionPools.get(map)?.get(poolName) ?? [];
+
+const addToPool = (
+  map: mapboxgl.Map,
+  poolName: string,
+  layerID: string,
+  handler: MapEventHandler
+) => {
+  // Create pools for this mapbox map if they don't already exist
+  if (!interactionPools.get(map)) {
+    interactionPools.set(map, new Map());
+  }
+
+  // Create the pool on the mapbox map if it doesn't already exist
+  if (!interactionPools.get(map)?.get(poolName)) {
+    interactionPools.get(map)?.set(poolName, new Map());
+  }
+
+  // Set a new handler for this layer in this pool on this mapbox map
+  interactionPools.get(map)?.get(poolName)?.set(layerID, handler);
+};
+
+const removeFromPool = (
+  map: mapboxgl.Map,
+  poolName: string,
+  layerID: string
+) => {
+  interactionPools.get(map)?.get(poolName)?.delete(layerID);
+};
+
+const useMapLayerInteractions = ({
+  map,
+  layerID,
+  interactionPool: _interactionPool,
+  priority,
+  onClick,
+  onHoverEnter,
+  onHoverLeave,
+  onDragStart,
+  onDrag,
+  onDragEnd,
+}: MapInteractionHandlerOptions) => {
+  const poolId = useRef(poolAutoId++);
+  let interactionPool = _interactionPool;
+  if (!_interactionPool) interactionPool = `auto-pool-${poolId.current}`;
+
+  // Update the interaction pool membership list whenever the layerID or
+  // interactionPool ID change
+  useEffect(() => {
+    if (!map || !interactionPool) return;
+    addToPool(map, interactionPool, layerID);
+
+    // Capture values and clean up
+    const addedMap = map;
+    const addedPool = interactionPool;
+    const addedLayerID = layerID;
+    return () => {
+      removeFromPool(addedMap, addedPool, addedLayerID);
+    };
+  }, [layerID, interactionPool, map]);
+
+  const poolLayers =
+    map && interactionPool ? getPoolLayers(map, interactionPool) : [];
+};

--- a/src/hooks/useMapInteractions.ts
+++ b/src/hooks/useMapInteractions.ts
@@ -185,19 +185,21 @@ class MapboxEventHandlerPool {
     // Only fire hover events if the feature beneath the pointer has changed
     if (
       highestPriorityHoverableFeature?.properties?.id !==
-      this.lastHoverFeature?.properties?.id
+        this.lastHoverFeature?.properties?.id ||
+      highestPriorityHoverableFeature?.layer.id !==
+        this.lastHoverFeature?.layer.id
     ) {
       // Call the appropriate layer's registered onHoverLeave handler
-      if (!!this.lastHoverFeature?.properties?.id) {
+      if ((this.lastHoverFeature?.properties?.id ?? null) !== null) {
         this.layers
           .find((l) => l.id === this.lastHoverFeature?.layer.id)
-          ?.onHoverLeave?.(this.lastHoverFeature.properties?.id, e);
+          ?.onHoverLeave?.(this.lastHoverFeature?.properties?.id!, e);
       }
 
-      if (!!highestPriorityHoverableFeature?.properties?.id) {
+      if ((highestPriorityHoverableFeature?.properties?.id ?? null) !== null) {
         this.layers
-          .find((l) => l.id === highestPriorityHoverableFeature.layer.id)
-          ?.onHoverEnter?.(highestPriorityHoverableFeature.properties?.id, e);
+          .find((l) => l.id === highestPriorityHoverableFeature?.layer.id)
+          ?.onHoverEnter?.(highestPriorityHoverableFeature?.properties?.id, e);
       }
       this.lastHoverFeature = highestPriorityHoverableFeature;
     }

--- a/src/hooks/useMapLayer.ts
+++ b/src/hooks/useMapLayer.ts
@@ -1,0 +1,106 @@
+import { Map, AnyLayout, AnyPaint, Layer } from "mapbox-gl";
+import { useEffect } from "react";
+import useDeepCompareEffect from "use-deep-compare-effect";
+
+type GeoJSONSourceDataType =
+  | GeoJSON.Feature<GeoJSON.Geometry>
+  | GeoJSON.FeatureCollection<GeoJSON.Geometry>
+  | String;
+
+const useMapLayer = <TLayout = AnyLayout, TPaint = AnyPaint>(
+  map: Map | null,
+  id: string,
+  type: Layer["type"],
+  geojson: GeoJSONSourceDataType,
+  style: { layout: TLayout; paint: TPaint },
+  onAdd?: (id: string) => void
+) => {
+  useEffect(() => {
+    if (!map) return;
+    // Start with a blank source — data will be added below via the
+    // `useMapSourceGeoJSON` hook
+    map.addSource(id, {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [] },
+    });
+
+    map.addLayer({
+      id: id,
+      paint: style.paint,
+      layout: style.layout,
+      source: id,
+      type,
+    });
+
+    onAdd?.(id);
+
+    return () => {
+      try {
+        map.removeLayer(id);
+        map.removeSource(id);
+      } catch (e) {
+        // Map was already un-mounted;
+      }
+    };
+    // Ignore changes to style — they will be updated separately via the
+    // `useMapLayerStyle` hook
+    // eslint-disable-next-line
+  }, [map, id, type]);
+
+  // Synchronize style state
+  useMapLayerStyle(map, id, style);
+
+  // Synchronize GeoJSON data source state
+  useMapSourceGeoJSON(map, id, geojson);
+};
+
+/** Synchronize a Mapbox layer's style with a style object passed down through
+ *  props.
+ */
+const useMapLayerStyle = (
+  map: Map | null,
+  layerID: string,
+  style: { layout: AnyLayout; paint: AnyPaint }
+) => {
+  // Update style whenever it changes
+  useDeepCompareEffect(() => {
+    if (!map) return;
+    // Copy over paint and layout properties one by one because that's the way
+    // Mapbox rolls.
+    for (const prop in style.paint) {
+      map.setPaintProperty(
+        layerID,
+        prop,
+        style.paint[prop as keyof typeof style.paint]
+      );
+    }
+    for (const prop in style.layout) {
+      map.setLayoutProperty(
+        layerID,
+        prop,
+        style.layout[prop as keyof typeof style.layout]
+      );
+    }
+  }, [map, layerID, style]);
+};
+
+/** Synchronize a Mapbox layer's data with a GeoJSON object passed down */
+const useMapSourceGeoJSON = (
+  map: Map | null,
+  id: string,
+  geojson: GeoJSONSourceDataType
+) => {
+  // Set data on initial load and whenever it changes
+  useEffect(() => {
+    if (!map) return;
+
+    const source = map.getSource(id);
+    if (source?.type !== "geojson") {
+      console.warn("Source should be geojson. Cannot set data.");
+    } else {
+      source.setData(geojson);
+    }
+  }, [map, id, geojson]);
+};
+
+export default useMapLayer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 // Import and re-export all objects and types this library should expose
 import MapboxMap from "./components/MapboxMap";
 import DOMLayer from "./components/layers/DOMLayer";
-import LineLayer from "./components/layers/LineLayer";
 import RasterLayer from "./components/layers/RasterLayer";
 import CustomLayer from "./components/layers/CustomLayer";
 import MapboxMapContext from "./contexts/MapboxContext";
 import PointLayer from "./components/layers/PointLayer";
+import LineLayer from "./components/layers/LineLayer";
 import InteractivePointLayer from "./components/layers/InteractivePointLayer";
+import InteractiveLineLayer from "./components/layers/InteractiveLineLayer";
 
 import useMapEvent from "./hooks/useMapEvent";
 
@@ -18,6 +19,7 @@ export {
   CustomLayer,
   PointLayer,
   InteractivePointLayer,
+  InteractiveLineLayer,
   MapboxMapContext,
   useMapEvent,
 };


### PR DESCRIPTION
This PR adds an InteractiveLineLayer component based on the InteractivePointLayer component. It also refactors most of the shared logic out to the `useMapLayer()` and `useMapInteractions()` custom hooks.