### PR TITLE
Fix 'trapMouse' handling of `DOMLayer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/components/layers/DOMLayer/index.tsx
+++ b/src/components/layers/DOMLayer/index.tsx
@@ -115,6 +115,9 @@ const MapboxDOMLayer: React.FC<MapboxDOMLayerProps> = ({
             onWheel={!trapScroll ? scrollHandler : undefined}
             onPointerDown={!trapMouse ? pointerHandler : undefined}
             onPointerUp={!trapMouse ? pointerHandler : undefined}
+            onMouseDown={!trapMouse ? pointerHandler : undefined}
+            onMouseUp={!trapMouse ? pointerHandler : undefined}
+
           >
             {children}
           </div>


### PR DESCRIPTION
The `trapMouse={false}` property on `DOMLayer` had no impact if the mouse was used to drag the map.