### PR TITLE
Do not render unless necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -88,10 +88,10 @@ const MapboxMap: React.FC<MapboxMapProps> = ({
       const pitch = newMap.getPitch();
       // no need to update the state if the values are the same
       if (zoom !== transformRef.current?.zoom
-        && center[0] !== transformRef.current?.center[0]
-        && center[1] !== transformRef.current?.center[1]
-        && bearing !== transformRef.current?.bearing
-        && pitch !== transformRef.current?.pitch) {
+        || center[0] !== transformRef.current?.center[0]
+        || center[1] !== transformRef.current?.center[1]
+        || bearing !== transformRef.current?.bearing
+        || pitch !== transformRef.current?.pitch) {
         setTransform({
           zoom,
           center,

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -52,6 +52,9 @@ const MapboxMap: React.FC<MapboxMapProps> = ({
 
   // Store map transform data in state so we can pass it to children
   const [transform, setTransform] = useState<MapboxMapTransform | null>(null);
+  // maintain this reference so we can access it in the useEffect below without including it in the dependency array
+  const transformRef = useRef(transform);
+  transformRef.current = transform;
 
   // Let the parent component overwrite the map bounds
   useDeepCompareEffectNoCheck(() => {
@@ -84,7 +87,11 @@ const MapboxMap: React.FC<MapboxMapProps> = ({
       const bearing = newMap.getBearing();
       const pitch = newMap.getPitch();
       // no need to update the state if the values are the same
-      if (zoom !== transform?.zoom && center !== transform?.center && bearing !== transform?.bearing && pitch !== transform?.pitch) {
+      if (zoom !== transformRef.current?.zoom
+        && center[0] !== transformRef.current?.center[0]
+        && center[1] !== transformRef.current?.center[1]
+        && bearing !== transformRef.current?.bearing
+        && pitch !== transformRef.current?.pitch) {
         setTransform({
           zoom,
           center,
@@ -168,14 +175,14 @@ const MapboxMap: React.FC<MapboxMapProps> = ({
     }
   }, [showControls, map]);
 
-  const containerBounds = mapContainer.current?.getBoundingClientRect();
+  const { width: containerBoundsWidth, height: containerBoundsHeight } = mapContainer.current?.getBoundingClientRect() || {};
 
   const providerValue = useMemo(() => ({
     map,
-    width: containerBounds?.width || 0,
-    height: containerBounds?.height || 0,
+    width: containerBoundsWidth || 0,
+    height: containerBoundsHeight || 0,
     transform,
-  }), [map, containerBounds, transform]);
+  }), [map, containerBoundsWidth, containerBoundsHeight, transform]);
 
   return (
     <>


### PR DESCRIPTION
In [this PR](https://github.com/wavespotter/tell-tale/pull/1752) we found that extra renders in the mapbox context provider were contributing to infinite recursion when rendering the map. This PR cleans up memoization for the provider to only change the value when it is actually necessary.

This also fixes a crash that could happen if the map is loaded really skinny:
![image](https://github.com/wavespotter/mapbox-context/assets/930901/9e72f41d-f09c-4c36-81cb-80051dea8dd7)

Tested locally with an RC package on npm.