### PR TITLE
Add Mapbox and OpenStreetMap attributions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.1.0",
+  "version": "2.1.1-rc.0",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "author": "Wayfinder Engineering <eng-wayfinder@sofarocean.com>",
   "license": "MIT",
   "private": false,
-  "repository": "https://github.com/wavespotter/mapbox-context",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wavespotter/mapbox-context.git"
+  },
   "homepage": "https://github.com/wavespotter/mapbox-context",
   "files": [
     "package.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.1.1-rc.0",
+  "version": "2.1.1-rc.1",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.1.1-rc.3",
+  "version": "2.1.1-rc.4",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.1.1-rc.4",
+  "version": "2.2.0",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.1.1-rc.1",
+  "version": "2.1.1-rc.2",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.41.0",
     "vite": "^7.1.2",
+    "vite-plugin-css-injected-by-js": "^4.0.1",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^3.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.1.1-rc.2",
+  "version": "2.1.1-rc.3",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -103,7 +103,7 @@ const MapboxMap = ({
     });
     newMap.addControl(new mapboxgl.AttributionControl({
       customAttribution: 'ECMWF'
-    }), "bottom");
+    }), "bottom-left");
     newMap.on("load", () => {
       setMap(newMap);
     });

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -101,6 +101,9 @@ const MapboxMap = ({
       transformRequest,
       accessToken: token,
     });
+    newMap.addControl(new mapboxgl.AttributionControl({
+      customAttribution: 'Based on data and products of the European Center for Medium-Range Weather Forecasts (ECMWF)'
+    }), 'bottom-left');
     newMap.on("load", () => {
       setMap(newMap);
     });

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -102,8 +102,8 @@ const MapboxMap = ({
       accessToken: token,
     });
     newMap.addControl(new mapboxgl.AttributionControl({
-      customAttribution: 'Based on data and products of the European Center for Medium-Range Weather Forecasts (ECMWF)'
-    }), 'bottom-left');
+      customAttribution: 'European Center for Medium-Range Weather Forecasts'
+    }));
     newMap.on("load", () => {
       setMap(newMap);
     });

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -102,8 +102,8 @@ const MapboxMap = ({
       accessToken: token,
     });
     newMap.addControl(new mapboxgl.AttributionControl({
-      customAttribution: 'European Center for Medium-Range Weather Forecasts'
-    }));
+      customAttribution: 'ECMWF'
+    }), "bottom");
     newMap.on("load", () => {
       setMap(newMap);
     });

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -1,3 +1,4 @@
+import "./map.css";
 import mapboxgl, {
   LngLatBoundsLike,
   LngLatLike,
@@ -101,9 +102,7 @@ const MapboxMap = ({
       transformRequest,
       accessToken: token,
     });
-    newMap.addControl(new mapboxgl.AttributionControl({
-      customAttribution: 'ECMWF'
-    }), "bottom-left");
+    newMap.addControl(new mapboxgl.AttributionControl(), "bottom-left");
     newMap.on("load", () => {
       setMap(newMap);
     });

--- a/src/components/MapboxMap/map.css
+++ b/src/components/MapboxMap/map.css
@@ -1,0 +1,4 @@
+.mapboxgl-ctrl-bottom-left {
+  display: flex;
+  flex-direction: column-reverse;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,12 @@ import { dirname } from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { extname, relative, resolve } from "path";
 import { defineConfig } from "vite";
+import cssInjectedByJs from "vite-plugin-css-injected-by-js";
 import dts from "vite-plugin-dts";
 
 export default defineConfig({
   plugins: [
+    cssInjectedByJs(),
     dts({
       exclude: ["**/*.stories.tsx", "**/storybook-helpers/*"],
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4010,11 +4010,6 @@ node-releases@^2.0.19:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
   integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
 
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
 open@^8.0.4:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
@@ -4870,6 +4865,11 @@ vite-node@3.2.4:
     es-module-lexer "^1.7.0"
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
+vite-plugin-css-injected-by-js@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-4.0.1.tgz#ed69dd8f04800f9e3c7a17c3a2e3819eede6092e"
+  integrity sha512-WfyRojojQyAO/KzWf+efcXpTPv6zJPXaRmr9EYq5a4v5I3PWCR7kR01hiri2lW6+rHm3a57kpwsf+iahIJi1Qw==
 
 vite-plugin-dts@^4.5.4:
   version "4.5.4"


### PR DESCRIPTION
We need to add the Mapbox/OpenStreetMap attribution to the map so that we're not in violation of Mapbox's license. The only place on the map that this would be easily visible and not covered by something in Wayfinder is the bottom-left. This however is also where the Mapbox logo (also required) is and this causes the attribution to stack on top of the logo, which is ugly. Instead, you can use `column-reverse` flex layout to put the attribution under the logo which visually makes more sense.

In order to include this CSS in the library and not force apps that consume this library to include custom CSS, I added a small CSS file and a Vite plugin that injects the CSS into the JS build. This ensures that any app consuming this library gets the correct styling with no changes needed on the consuming end.

We could inject the CSS manually since it's so small and avoided the new dependency, but I figured this is more future-proof and extensible for a fairly small price, complexity-wise.

<img width="1279" height="346" alt="Screenshot 2026-03-19 at 1 46 50 PM" src="https://github.com/user-attachments/assets/ec2a3d3d-18a4-42a9-a4fe-8ad5214f9e77" />

I also plan to bump the minor version to 2.2.0 to publish this.

You can see this being used in Wayfinder here: https://deploy-preview-3129--sofar-tell-tale-staging.netlify.app/fleet

We'll also need a follow-up PR to add ECMWF attribution but there's ongoing discussion about what that should look like, so we'll get this change in for now.