### PR TITLE
Expand react peer dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        react: [18, 19]
+        react: [15, 18, 19]
 
     runs-on: ubuntu-latest
     steps:
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run build
         run: yarn build
+
+      - name: Run tests
+        run: yarn test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install
+          # Overwrite react dependencies to test compatibility with different versions
           yarn add -D react@${{ matrix.react }}
+          yarn add -D react-dom@${{ matrix.react }}
 
       - name: Run build
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run build
         run: yarn build
 
-      - name: Run tests
-        run: yarn test
+      - name: Run typecheck
+        run: yarn typecheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,13 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install
+
           # Overwrite react dependencies to test compatibility with different versions
-          yarn add -D react@${{ matrix.react }}
-          yarn add -D react-dom@${{ matrix.react }}
+          yarn add -D \
+            react@${{ matrix.react }} \
+            react-dom@${{ matrix.react }} \
+            @types/react@${{ matrix.react }} \
+            @types/react-dom@${{ matrix.react }} \
 
       - name: Run build
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        react: [15]
-        # react: [18, 19]
+        react: [18, 19]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,17 @@ name: Build
 
 on:
   pull_request:
-    types: 
+    types:
       - opened
       - reopened
       - synchronize
 
 jobs:
   build:
+    strategy:
+      matrix:
+        react: [18, 19]
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +24,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: yarn install
+        run: |
+          yarn install
+          yarn add -D react@${{ matrix.react }}
 
       - name: Run build
         run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
   build:
     strategy:
       matrix:
-        react: [15, 18, 19]
+        react: [15]
+        # react: [18, 19]
 
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -70,3 +70,14 @@ const MyMapComponent = () => {
   return <div>Last clicked position was: ({position?.join(", ")})</div>;
 };
 ```
+
+## Releasing
+
+Releases are done manually, locally. To create a new release do the following:
+
+1. **Bump the `version` in `package.json`:** This indicates new package version to NPM.
+1. **`yarn build`:** This makes a `/dist` build directory that gets bumped into the NPM package.
+1. **`npm publish`:** This makes actually sends the new package to NPM.
+1. **Create a new commit and merge it:** Mostly so we commit the current package version. This can also be done before the other steps.
+
+Often it's useful to test a change to this package in something that consumes it. In that case, you can make a version and suffix it with `-rc1` to denote "release candidate 1".

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^9.34.0",
     "glob": "^11.0.3",
     "knip": "^5.62.0",
+    "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^9.1.2",
     "tsx": "^4.20.4",
@@ -64,7 +65,7 @@
     "@turf/turf": "^7.2.0",
     "fast-equals": "^5.2.2",
     "mapbox-gl": "^3.14.0",
-    "react": "^18.2.0",
+    "react": "^18.2.0 || ^19.0",
     "use-deep-compare-effect": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.2.0",
+  "version": "2.3.0-rc2",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@turf/turf": "^7.2.0",
     "fast-equals": "^5.2.2",
     "mapbox-gl": "^3.14.0",
-    "react": "^18.2.0",
     "use-deep-compare-effect": "^1.3.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarocean/mapbox-context",
-  "version": "2.3.0-rc2",
+  "version": "2.3.0",
   "description": "A React wrapper for Mapbox GL JS built for the era of React Context and Hooks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/MapboxMap/index.tsx
+++ b/src/components/MapboxMap/index.tsx
@@ -186,7 +186,7 @@ const MapboxMap = ({
     }
   }, [touchPitch, map]);
 
-  const zoomControl = useRef<ZoomControl>();
+  const zoomControl = useRef<ZoomControl>(undefined);
   useEffect(() => {
     if (showControls) {
       zoomControl.current = new ZoomControl();
@@ -206,7 +206,7 @@ const MapboxMap = ({
       height: containerBoundsHeight || 0,
       transform,
     }),
-    [map, containerBoundsWidth, containerBoundsHeight, transform]
+    [map, containerBoundsWidth, containerBoundsHeight, transform],
   );
 
   return (

--- a/src/components/layers/LineLayer/LineLayer.stories.tsx
+++ b/src/components/layers/LineLayer/LineLayer.stories.tsx
@@ -99,7 +99,7 @@ const lineStyle: {
 };
 
 const Template: StoryFn<LineLayerProps> = (
-  args: JSX.IntrinsicAttributes &
+  args: React.JSX.IntrinsicAttributes &
     LineLayerProps & { children?: React.ReactNode }
 ) => <LineLayer {...args} />;
 

--- a/src/components/layers/PointLayer/PointLayer.stories.tsx
+++ b/src/components/layers/PointLayer/PointLayer.stories.tsx
@@ -56,7 +56,7 @@ const symbolStyle: {
 };
 
 const Template: StoryFn<PointLayerProps> = (
-  args: JSX.IntrinsicAttributes &
+  args: React.JSX.IntrinsicAttributes &
     PointLayerProps & { children?: React.ReactNode }
 ) => <PointLayer {...args} />;
 

--- a/src/hooks/use-image-loader.tsx
+++ b/src/hooks/use-image-loader.tsx
@@ -21,7 +21,7 @@ const useImageLoader = (
   map: mapboxgl.Map | null,
   imageDefs: ImageDefinition[] | undefined
 ) => {
-  const recentImageDefs = useRef<ImageDefinition[] | undefined>();
+  const recentImageDefs = useRef<ImageDefinition[] | undefined>(undefined);
   const [images, setImages] = useState<ImageStatus>({});
   const [loadingComplete, setLoadingComplete] = useState(false);
 

--- a/src/storybook-helpers/map-decorator.tsx
+++ b/src/storybook-helpers/map-decorator.tsx
@@ -1,4 +1,4 @@
-import { StoryFn } from "@storybook/react/types-6-0";
+import { Decorator } from "@storybook/react";
 import React from "react";
 import MapboxMap from "../components/MapboxMap";
 
@@ -7,17 +7,16 @@ export default ({
     height = "400px",
     zoom = 2,
     center = { lat: 0, lng: 0 },
-  } = {}) =>
-  (Story: StoryFn) =>
-    (
-      <MapboxMap
-        token="pk.eyJ1Ijoiam9uc2VuIiwiYSI6IkR6UU9oMDQifQ.dymRIgqv-UV6oz0-HCFx1w"
-        styleUrl="mapbox://styles/jonsen/ckcgprwic1bxz1is2tvd560pg"
-        width={width}
-        height={height}
-        zoom={zoom}
-        center={center}
-      >
-        <Story />
-      </MapboxMap>
-    );
+  } = {}): Decorator =>
+  (Story) => (
+    <MapboxMap
+      token="pk.eyJ1Ijoiam9uc2VuIiwiYSI6IkR6UU9oMDQifQ.dymRIgqv-UV6oz0-HCFx1w"
+      styleUrl="mapbox://styles/jonsen/ckcgprwic1bxz1is2tvd560pg"
+      width={width}
+      height={height}
+      zoom={zoom}
+      center={center}
+    >
+      <Story />
+    </MapboxMap>
+  );


### PR DESCRIPTION
I want to upgrade tell-tale to React 19 but this library has its react version pinned to 18. This creates some problems because we actually end up with 2 versions of react in our bundle. I also _think_ things break when i upgrade to react 19 because of it, although i'm not 100% this is the cause. regardless this seems like it's just a good thing to do.

the approach here is to provide multiple peer dependency versions for react and then move the react dep in the library to a dev dependency. the dev dependency lets us get _something_ to use while developing and stuff but it won't be included in the actual bundle. I also made a few changes to the repo to get react19 typechecking to pass, mainly just using `React.JSX` and `useRef(undefined)`.

this library has no tests, so i tried to add some "testing" by making a matrix of react versions and then typechecking against those. I also made a release candidate version `2.3.0-rc3` and tried it in tell-tale [here](https://github.com/wavespotter/tell-tale/pull/3615) and it seems to work